### PR TITLE
osquery_conf packs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+
+Thorfile
+
+# Bundler
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Custom Resources
 ```ruby
 osquery_conf '/etc/osquery/osquery.conf' do
   action :create
-  schedule schedule_config
-  notifies :restart, 'service[osqueryd]'
+  schedule node['osquery']['schedule']
+  packs node['osquery']['packs']
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,25 +2,32 @@ osquery chef cookbook
 ====================
 [![Build Status](https://travis-ci.org/jacknagz/osquery-cookbook.svg?branch=master)](https://travis-ci.org/jacknagz/osquery-cookbook)
 
-* Installs, configures, and starts [osquery](https://osquery.io/). 
-* Supports: OS X, Ubuntu, and Centos (soon).
+* Installs, configures, and starts [osquery](https://osquery.io/).
 * Configurations are generated based on node attributes.
 
-Requirements
+Supported Platforms
 ------------
 * OS X
-  * [Xcode Command Line Tools](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
+  * Requires [Xcode Command Line Tools](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
+* Ubuntu
+* Centos
+* Redhat
 
 General Attributes
 ----------
+`attributes/default.rb`:
+
 | name   | type | default | description |
 |--------|------|---------|-------------|
 | `['osquery']['version']` | `String` | `1.7.0` | osquery version to install |
-| `['osquery']['supported']` | `Array` | `%w(mac_os_x ubuntu)` | supported platforms |
 | `['osquery']['packs']` | `Array` | `%w(incident-response osx-attacks)` | osquery packs found in `files/default/packs/` |
+| `['osquery']['repo']['checksum6']` | `String` | - | SHA256 Hash of the centos6 repo |
+| `['osquery']['repo']['checksum7']` | `String` | - | SHA256 Hash of the centos7 repo |
 
 Configuration Attributes
 ----------
+`attributes/config.rb`:
+
 | name   | type | default | description |
 |--------|------|---------|-------------|
 | `['osquery']['options']['config_plugin']` | `String` | `filesystem` | configuration plugin |
@@ -32,9 +39,25 @@ Configuration Attributes
 | `['osquery']['options']['worker_threads']` | `Fixnum` | `2` | number of work dispatch threads |
 | `['osquery']['options']['enable_monitor']` | `Boolean` | `false` | enable schedule monitor |
 
+Query Schedule Attributes
+----------
+`attributes/schedule.rb`:
+
+| name   | type | default | description |
+|--------|------|---------|-------------|
+| `['osquery']['schedule']` | `Hash` | - | osquery schedule |
+
+File Integrity Monitoring Attributes
+----------
+`attributes/file_paths.rb`:
+
+| name   | type | default | description |
+|--------|------|---------|-------------|
+| `['osquery']['file_paths']` | `Hash` | - | file paths to monitor events from |
+
 Custom Resources
 ----------------
-* osquery_conf: create osquery config from selected options and packs.
+`osquery_conf`: create osquery config from selected options and packs.
 
 `create`:
 
@@ -56,11 +79,17 @@ end
 
 Testing
 -----
-`$ rake`: executes `foodcritic`, `rubocop`, and `chefspec`.
+`$ rake` to run:
+* `foodcritic`
+* `rubocop`
+* `chefspec`.
+
+`$ kitchen list` to show integration test suites <br />
+`$ kitchen converge` to run test suites
 
 Usage
 -----
-Include `osquery` in your node's `run_list`!
+Include `osquery` in your node's `run_list`, and override attributes to fit your desired setup.
 
 Contributing
 ------------
@@ -73,4 +102,5 @@ Contributing
 
 License and Authors
 -------------------
-Authors: Jack Naglieri <jnaglierijr@gmail.com>
+Authors: Jack Naglieri <jacknagzdev@gmail.com>
+License: 'Apache 2.0'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -1,3 +1,4 @@
+# osquery daemon configuration.
 default['osquery']['options']['config_plugin']  = 'filesystem'
 default['osquery']['options']['logger_plugin']  = 'filesystem'
 default['osquery']['options']['logger_path']    = '/var/log/osquery'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,9 @@
+# Yum repo checksums, osquery version, and packs.
 default['osquery']['repo']['checksum6'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
 default['osquery']['repo']['checksum7'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
-default['osquery']['supported'] = %w(
-  mac_os_x
-  ubuntu
-  centos
-)
+
+default['osquery']['version'] = '1.7.0'
 default['osquery']['packs'] = %w(
   incident-response
   osx-attacks
 )
-default['osquery']['version'] = '1.7.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 default['osquery']['repo']['checksum6'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
 default['osquery']['repo']['checksum7'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
 
-default['osquery']['version'] = '1.7.0'
+default['osquery']['version'] = '1.7.3'
 default['osquery']['packs'] = %w(
   incident-response
   osx-attacks

--- a/attributes/file_paths.rb
+++ b/attributes/file_paths.rb
@@ -1,0 +1,13 @@
+# FIM configuration.
+default['osquery']['file_paths'] = {
+  homes: [
+    '/root/.ssh/%%',
+    '/home/%/.ssh/%%'
+  ],
+  etc: [
+    '/etc/%%'
+  ],
+  tmp: [
+    '/tmp/%%'
+  ]
+}

--- a/attributes/file_paths.rb
+++ b/attributes/file_paths.rb
@@ -1,7 +1,6 @@
 # FIM configuration.
 default['osquery']['file_paths'] = {
   homes: [
-    '/root/.ssh/%%',
     '/home/%/.ssh/%%'
   ],
   etc: [

--- a/attributes/schedule.rb
+++ b/attributes/schedule.rb
@@ -1,0 +1,7 @@
+# Example schedule config.
+default['osquery']['schedule'] = {
+  info: {
+    query: 'SELECT * FROM osquery_info',
+    interval: '86400'
+  }
+}

--- a/attributes/schedule.rb
+++ b/attributes/schedule.rb
@@ -1,7 +1,12 @@
 # Example schedule config.
 default['osquery']['schedule'] = {
   info: {
-    query: 'SELECT * FROM osquery_info',
-    interval: '86400'
+    query: 'SELECT * FROM osquery_info;',
+    interval: 86_400
+  },
+  file_events: {
+    query: 'SELECT * FROM file_events;',
+    removed: false,
+    interval: 300
   }
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.4.0'
 
 %w(ubuntu centos mac_os_x).each do |os|
   supports os

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -5,14 +5,6 @@
 # Copyright 2016, Jack Naglieri
 #
 
-# Example schedule config.
-schedule_config = {
-  info: {
-    query: 'SELECT * FROM osquery_info',
-    interval: '86400'
-  }
-}
-
 centos_version = node['platform_version'].split('.')[0].to_i
 repo_checksum = node['osquery']['repo']["checksum#{centos_version}"]
 repo_url = "https://osquery-packages.s3.amazonaws.com/centos#{centos_version}/noarch"
@@ -36,19 +28,9 @@ package 'osquery' do
 end
 
 osquery_conf '/etc/osquery/osquery.conf' do
-  action :create
-  schedule schedule_config
+  schedule node['osquery']['schedule']
+  packs node['osquery']['packs']
   notifies :restart, 'service[osqueryd]'
-end
-
-node['osquery']['packs'].each do |pack|
-  cookbook_file "/usr/share/osquery/packs/#{pack}.conf" do
-    mode '0444'
-    source "packs/#{pack}.conf"
-    owner 'root'
-    group 'root'
-    notifies :restart, 'service[osqueryd]'
-  end
 end
 
 service 'osqueryd' do

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -30,6 +30,7 @@ end
 osquery_conf '/etc/osquery/osquery.conf' do
   schedule node['osquery']['schedule']
   packs node['osquery']['packs']
+  fim_paths node['osquery']['file_paths']
   notifies :restart, 'service[osqueryd]'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,9 +5,20 @@
 # Copyright 2016, Jack Naglieri
 #
 
-unless node['osquery']['supported'].include?(node['platform'])
+supported_platforms = %w(
+  mac_os_x
+  ubuntu
+  centos
+  redhat
+)
+
+unless supported_platforms.include?(node['platform'])
   Chef::Log.warn("** Unsupported version #{node['platform']} **")
   return
 end
 
-include_recipe "osquery::#{node['platform']}"
+if node['platform'].eql?('redhat')
+  include_recipe 'osquery::centos'
+else
+  include_recipe "osquery::#{node['platform']}"
+end

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -5,14 +5,6 @@
 # Copyright 2016, Jack Naglieri
 #
 
-# Example schedule config.
-schedule_config = {
-  info: {
-    query: 'SELECT * FROM osquery_info',
-    interval: '86400'
-  }
-}
-
 ubuntu_version = node['platform_version'].split('.')[0].to_i
 case ubuntu_version
 when 14
@@ -38,19 +30,9 @@ package 'osquery' do
 end
 
 osquery_conf '/etc/osquery/osquery.conf' do
-  action :create
-  schedule schedule_config
+  schedule node['osquery']['schedule']
+  packs node['osquery']['packs']
   notifies :restart, 'service[osqueryd]'
-end
-
-node['osquery']['packs'].each do |pack|
-  cookbook_file "/usr/share/osquery/packs/#{pack}.conf" do
-    mode '0444'
-    source "packs/#{pack}.conf"
-    owner 'root'
-    group 'root'
-    notifies :restart, 'service[osqueryd]'
-  end
 end
 
 service 'osqueryd' do

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -1,26 +1,54 @@
 property :osquery_conf, kind_of: String, name_property: true
-property :schedule, kind_of: Hash, default: {}
+property :schedule, kind_of: Hash, default: {}, required: true
+property :packs, kind_of: Array, default: []
+property :file_paths, kind_of: Hash, default: {}
 
 default_action :create
 
 action :create do
-  packs_config = {}
-  case node['platform']
-  when 'mac_os_x'
-    packs_dir = '/var/osquery/packs'
-  when 'centos' || 'ubuntu'
-    packs_dir = '/usr/share/osquery/packs'
-  end
+  if packs.empty?
 
-  node['osquery']['packs'].each do |pack|
-    packs_config[pack] = "#{packs_dir}/#{pack}.conf"
-  end
+    config_hash = {
+      options: node['osquery']['options'],
+      schedule: schedule
+    }
 
-  config_hash = {
-    options: node['osquery']['options'],
-    schedule: schedule,
-    packs: packs_config
-  }
+  else
+
+    packs_config = {}
+    case node['platform']
+    when 'mac_os_x'
+      packs_dir = '/var/osquery/packs'
+    when 'centos', 'ubuntu'
+      packs_dir = '/usr/share/osquery/packs'
+    end
+
+    directory '/var/osquery/packs' do
+      recursive true
+      mode 0755
+      only_if { node['platform'].eql?('mac_os_x') }
+    end
+
+    packs.each do |pack|
+      cookbook_file "#{packs_dir}/#{pack}.conf" do
+        mode '0444'
+        source "packs/#{pack}.conf"
+        owner 'root'
+        group 'root'
+      end
+    end
+
+    packs.each do |pack|
+      packs_config[pack] = "#{packs_dir}/#{pack}.conf"
+    end
+
+    config_hash = {
+      options: node['osquery']['options'],
+      schedule: schedule,
+      packs: packs_config
+    }
+
+  end
 
   template osquery_conf do
     source 'osquery.conf.erb'
@@ -36,5 +64,10 @@ end
 action :delete do
   file '/etc/osquery/osquery.conf' do
     action :delete
+  end
+
+  directory packs_dir do
+    action :delete
+    recursive true
   end
 end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -1,19 +1,17 @@
 property :osquery_conf, kind_of: String, name_property: true
 property :schedule, kind_of: Hash, default: {}, required: true
 property :packs, kind_of: Array, default: []
-property :file_paths, kind_of: Hash, default: {}
+property :fim_paths, kind_of: Hash, default: {}
 
 default_action :create
 
 action :create do
-  if packs.empty?
+  config_hash = {
+    options: node['osquery']['options'],
+    schedule: schedule
+  }
 
-    config_hash = {
-      options: node['osquery']['options'],
-      schedule: schedule
-    }
-
-  else
+  unless packs.empty?
 
     packs_config = {}
     case node['platform']
@@ -23,10 +21,10 @@ action :create do
       packs_dir = '/usr/share/osquery/packs'
     end
 
-    directory '/var/osquery/packs' do
+    directory packs_dir do
+      action :create
       recursive true
       mode 0755
-      only_if { node['platform'].eql?('mac_os_x') }
     end
 
     packs.each do |pack|
@@ -35,6 +33,7 @@ action :create do
         source "packs/#{pack}.conf"
         owner 'root'
         group 'root'
+        # TODO: source cookbook option
       end
     end
 
@@ -42,13 +41,10 @@ action :create do
       packs_config[pack] = "#{packs_dir}/#{pack}.conf"
     end
 
-    config_hash = {
-      options: node['osquery']['options'],
-      schedule: schedule,
-      packs: packs_config
-    }
-
+    config_hash[:packs] = packs_config
   end
+
+  config_hash[:file_paths] = fim_paths unless fim_paths.empty?
 
   template osquery_conf do
     source 'osquery.conf.erb'
@@ -64,6 +60,13 @@ end
 action :delete do
   file '/etc/osquery/osquery.conf' do
     action :delete
+  end
+
+  case node['platform']
+  when 'mac_os_x'
+    packs_dir = '/var/osquery/packs'
+  when 'centos', 'ubuntu'
+    packs_dir = '/usr/share/osquery/packs'
   end
 
   directory packs_dir do

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe 'osquery::centos' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
+    ChefSpec::SoloRunner.new(platform: 'centos',
+                             version: '7.0',
+                             step_into: ['osquery_conf']
+                            ) do |node|
       node.set['osquery']['packs'] = %w(centos_pack)
     end.converge(described_recipe)
   end
@@ -17,9 +20,14 @@ describe 'osquery::centos' do
     expect(chef_run).to install_package('osquery')
   end
 
-  it 'installs the centos pack' do
+  it 'installs the centos pack via lwrp' do
     expect(chef_run)
       .to create_cookbook_file('/usr/share/osquery/packs/centos_pack.conf')
+  end
+
+  it 'creates osquery conf via lwrp' do
+    expect(chef_run)
+      .to create_template('/etc/osquery/osquery.conf')
   end
 
   it 'install osquery repo' do

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -34,8 +34,12 @@ describe 'osquery::centos' do
     expect(chef_run).to_not install_rpm_package('osquery repo')
   end
 
-  it 'fetches osquery repo' do
+  it 'get osquery repo' do
     expect(chef_run).to create_remote_file("#{Chef::Config['file_cache_path']}/#{repo}")
+  end
+
+  it 'creates directory if its missing' do
+    expect(chef_run).to create_directory('/usr/share/osquery/packs')
   end
 
   it 'creates osquery config' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -52,4 +52,20 @@ describe 'osquery::default' do
       expect { chef_run }.not_to raise_error
     end
   end
+
+  context 'when redhat' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0') do |node|
+        node.set['osquery']['packs'] = %w(centos_pack)
+      end.converge(described_recipe)
+    end
+
+    it 'includes centos installation recipe' do
+      expect(chef_run).to include_recipe('osquery::centos')
+    end
+
+    it 'converges without error' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
 end

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe 'osquery::mac_os_x' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.10') do |node|
+    ChefSpec::SoloRunner.new(platform: 'mac_os_x',
+                             version: '10.10',
+                             step_into: ['osquery_conf']
+                            ) do |node|
       node.set['osquery']['packs'] = %w(osx_pack)
     end.converge(described_recipe)
   end
@@ -40,6 +43,10 @@ describe 'osquery::mac_os_x' do
 
   it 'creates osquery config' do
     expect(chef_run).to create_osquery_config('/var/osquery/osquery.conf')
+  end
+
+  it 'creates osquery conf via lwrp' do
+    expect(chef_run).to create_template('/var/osquery/osquery.conf')
   end
 
   it 'creates osquery LaunchDaemon' do

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -14,7 +14,7 @@ describe 'osquery::mac_os_x' do
     stub_command('which git').and_return('/usr/bin/git')
   end
 
-  let(:osquery_vers) { '1.7.0' }
+  let(:osquery_vers) { '1.7.3' }
   let(:domain) { 'com.facebook.osqueryd' }
   osquery_dirs = [
     '/var/log/osquery',

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe 'osquery::ubuntu' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+    ChefSpec::SoloRunner.new(platform: 'ubuntu',
+                             version: '14.04',
+                             step_into: ['osquery_conf']
+                            ) do |node|
       node.set['osquery']['packs'] = %w(ubuntu_pack)
     end.converge(described_recipe)
   end
@@ -18,13 +21,13 @@ describe 'osquery::ubuntu' do
       .with(version: osquery_vers)
   end
 
-  it 'installs the ubuntu pack' do
-    expect(chef_run)
-      .to create_cookbook_file('/usr/share/osquery/packs/ubuntu_pack.conf')
-  end
-
   it 'creates osquery config' do
     expect(chef_run).to create_osquery_config('/etc/osquery/osquery.conf')
+  end
+
+  it 'installs the ubuntu pack via lwrp' do
+    expect(chef_run)
+      .to create_cookbook_file('/usr/share/osquery/packs/ubuntu_pack.conf')
   end
 
   it 'starts and enables osquery service' do

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -10,7 +10,7 @@ describe 'osquery::ubuntu' do
     end.converge(described_recipe)
   end
 
-  let(:osquery_vers) { '1.7.0-1.ubuntu14' }
+  let(:osquery_vers) { '1.7.3-1.ubuntu14' }
 
   it 'converges without error' do
     expect { chef_run }.not_to raise_error


### PR DESCRIPTION
* adds a property to `osquery_conf` for a list of packs to install from `files/default/packs`
* converts the schedule hash variable to a node attribute for more flexibility
* updated README