### PR TITLE
fix os x file group error, improved tests, and split rake tasks

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -13,7 +13,7 @@ GRAPH
   compat_resource (12.9.1)
   homebrew (2.1.0)
     build-essential (>= 2.1.2)
-  osquery (0.3.0)
+  osquery (0.4.1)
     apt (>= 0.0.0)
     compat_resource (>= 0.0.0)
     homebrew (>= 0.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,20 @@ require 'foodcritic'
 require 'rspec/core/rake_task'
 
 desc 'Run all tests'
-task test: [
+task all: [
   :rubocop,
   :foodcritic,
   :unit
 ]
+task lint: [
+  :rubocop,
+  :foodcritic
+]
+task test: [
+  :unit
+]
 
-task default: [:test]
+task default: [:all]
 
 desc 'Lists all the tasks.'
 task :list do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.0'
+version '0.4.1'
 
 %w(ubuntu centos mac_os_x).each do |os|
   supports os

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -23,11 +23,13 @@ describe 'osquery::centos' do
   it 'installs the centos pack via lwrp' do
     expect(chef_run)
       .to create_cookbook_file('/usr/share/osquery/packs/centos_pack.conf')
+      .with(group: 'root', user: 'root')
   end
 
   it 'creates osquery conf via lwrp' do
     expect(chef_run)
       .to create_template('/etc/osquery/osquery.conf')
+      .with(group: 'root', user: 'root')
   end
 
   it 'install osquery repo' do

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -39,6 +39,7 @@ describe 'osquery::mac_os_x' do
   it 'installs the a pack' do
     expect(chef_run)
       .to create_cookbook_file('/var/osquery/packs/osx_pack.conf')
+      .with(group: 'wheel', user: 'root')
   end
 
   it 'creates osquery config' do
@@ -46,16 +47,21 @@ describe 'osquery::mac_os_x' do
   end
 
   it 'creates osquery conf via lwrp' do
-    expect(chef_run).to create_template('/var/osquery/osquery.conf')
+    expect(chef_run)
+      .to create_template('/var/osquery/osquery.conf')
+      .with(group: 'wheel', user: 'root')
   end
 
   it 'creates osquery LaunchDaemon' do
     expect(chef_run)
       .to create_template("/Library/LaunchDaemons/#{domain}.plist")
+      .with(group: 'wheel', user: 'root')
   end
 
   it 'creates osquery syslog conf entry' do
-    expect(chef_run).to create_cookbook_file("/etc/newsyslog.d/#{domain}.conf")
+    expect(chef_run)
+      .to create_cookbook_file("/etc/newsyslog.d/#{domain}.conf")
+      .with(group: 'wheel', user: 'root')
   end
 
   it 'starts and enables osquery service' do

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -28,6 +28,7 @@ describe 'osquery::ubuntu' do
   it 'installs the ubuntu pack via lwrp' do
     expect(chef_run)
       .to create_cookbook_file('/usr/share/osquery/packs/ubuntu_pack.conf')
+      .with(group: 'root', user: 'root')
   end
 
   it 'starts and enables osquery service' do


### PR DESCRIPTION
* os x file group was set improperly to 'root', this change amends it to 'wheel'.
* unit tests have been improved to look for file resource attributes.
* split rake tasks for all, unit tests, and linting.
* v.0.4.1