### PR TITLE
v1.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 Metrics/LineLength:
-  Max: 110
+  Max: 120

--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,4 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'homebrew'
 cookbook 'apt'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -13,7 +13,7 @@ GRAPH
   compat_resource (12.9.1)
   homebrew (2.1.0)
     build-essential (>= 2.1.2)
-  osquery (1.0.0)
+  osquery (1.0.1)
     apt (>= 0.0.0)
     compat_resource (>= 0.0.0)
     homebrew (>= 0.0.0)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,23 +1,12 @@
 DEPENDENCIES
   apt
-  homebrew
   osquery
     path: .
     metadata: true
 
 GRAPH
   apt (3.0.0)
-  build-essential (3.2.0)
-    seven_zip (>= 0.0.0)
-  chef_handler (1.3.0)
   compat_resource (12.9.1)
-  homebrew (2.1.0)
-    build-essential (>= 2.1.2)
-  osquery (1.0.1)
+  osquery (1.1.0)
     apt (>= 0.0.0)
     compat_resource (>= 0.0.0)
-    homebrew (>= 0.0.0)
-  seven_zip (2.0.0)
-    windows (>= 1.2.2)
-  windows (1.39.2)
-    chef_handler (>= 0.0.0)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ General Attributes
 
 | name   | type | default | description |
 |--------|------|---------|-------------|
-| `['osquery']['version']` | `String` | `1.7.3` | osquery version to install |
+| `['osquery']['version']` | `String` | `1.7.4` | osquery version to install |
 | `['osquery']['packs']` | `Array` | `%w(incident-response osx-attacks)` | osquery packs found in `files/default/packs/` |
 | `['osquery']['pack_source']` | `String` | `osquery` | Cookbook to load osquery packs from |
 | `['osquery']['repo']['checksum6']` | `String` | - | SHA256 Hash of the centos6 repo |
@@ -47,7 +47,7 @@ Query Schedule Attributes
 
 | name   | type | default | description |
 |--------|------|---------|-------------|
-| `['osquery']['schedule']` | `Hash` | - | osquery schedule |
+| `['osquery']['schedule']` | `Hash` | osquery_info and file_events | osquery schedule |
 
 File Integrity Monitoring Attributes
 ----------
@@ -55,7 +55,8 @@ File Integrity Monitoring Attributes
 
 | name   | type | default | description |
 |--------|------|---------|-------------|
-| `['osquery']['file_paths']` | `Hash` | - | file paths to monitor events from |
+| `['osquery']['file_paths']` | `Hash` | homes, etc, and tmp | file paths to monitor events from |
+| `['osquery']['fim_enabled']` | `Boolean` | false | enable/disable file event tracking in config |
 
 Custom Resources
 ----------------

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ General Attributes
 | `['osquery']['version']` | `String` | `1.7.4` | osquery version to install |
 | `['osquery']['packs']` | `Array` | `%w(incident-response osx-attacks)` | osquery packs found in `files/default/packs/` |
 | `['osquery']['pack_source']` | `String` | `osquery` | Cookbook to load osquery packs from |
-| `['osquery']['repo']['checksum6']` | `String` | - | SHA256 Hash of the centos6 repo |
-| `['osquery']['repo']['checksum7']` | `String` | - | SHA256 Hash of the centos7 repo |
+| `['osquery']['repo']['el6_checksum']` | `String` | - | SHA256 Hash of the centos6 repo |
+| `['osquery']['repo']['el7_checksum']` | `String` | - | SHA256 Hash of the centos7 repo |
 
 Configuration Attributes
 ----------

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -1,9 +1,14 @@
-# osquery daemon configuration.
+# config/logger configuration.
 default['osquery']['options']['config_plugin']  = 'filesystem'
 default['osquery']['options']['logger_plugin']  = 'filesystem'
-default['osquery']['options']['logger_path']    = '/var/log/osquery'
+
+# daemon configuration.
 default['osquery']['options']['schedule_splay_percent'] = 10
 default['osquery']['options']['events_expiry']  = 3600
 default['osquery']['options']['verbose']        = false
 default['osquery']['options']['worker_threads'] = 2
 default['osquery']['options']['enable_monitor'] = false
+
+# extra options
+default['osquery']['syslog']['enabled'] = true
+default['osquery']['syslog']['filename'] = '/etc/rsyslog.d/60-osquery.conf'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['osquery']['repo']['checksum6'] = '5960044255a51feda80df816fc6769c2bf431
 default['osquery']['repo']['checksum7'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
 default['osquery']['repo']['internal'] = false
 
-default['osquery']['version'] = '1.7.3'
+default['osquery']['version'] = '1.7.4'
 default['osquery']['packs'] = %w(
   incident-response
   osquery-monitoring

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 # Yum repo checksums, osquery version, and packs.
-default['osquery']['repo']['checksum6'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
-default['osquery']['repo']['checksum7'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
+default['osquery']['repo']['osx_checksum'] = '74dabf0a08f3ed321183fd07583a6ff49c7fd779e08d978a501014df7b073ecc'
+default['osquery']['repo']['el6_checksum'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
+default['osquery']['repo']['el7_checksum'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
 default['osquery']['repo']['internal'] = false
 
 default['osquery']['version'] = '1.7.4'

--- a/attributes/file_paths.rb
+++ b/attributes/file_paths.rb
@@ -1,4 +1,5 @@
 # FIM configuration.
+default['osquery']['fim_enabled'] = false
 default['osquery']['file_paths'] = {
   homes: [
     '/home/%/.ssh/%%'

--- a/files/default/rsyslog/osquery-legacy.conf
+++ b/files/default/rsyslog/osquery-legacy.conf
@@ -1,0 +1,2 @@
+$template OsqueryCsvFormat, "%timestamp:::date-rfc3339,csv%,%hostname:::csv%,%syslogseverity:::csv%,%syslogfacility-text:::csv%,%syslogtag:::csv%,%msg:::csv%\n"
+*.* |/var/osquery/syslog_pipe;OsqueryCsvFormat

--- a/files/default/rsyslog/osquery.conf
+++ b/files/default/rsyslog/osquery.conf
@@ -1,0 +1,6 @@
+template(
+  name="OsqueryCsvFormat"
+  type="string"
+  string="%timestamp:::date-rfc3339,csv%,%hostname:::csv%,%syslogseverity:::csv%,%syslogfacility-text:::csv%,%syslogtag:::csv%,%msg:::csv%\n"
+)
+*.* action(type="ompipe" Pipe="/var/osquery/syslog_pipe" template="OsqueryCsvFormat")

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,5 @@
+require 'mixlib/shellout'
+
 # Helper modules for common case statements.
 module Osquery
   def compat_audit
@@ -34,6 +36,25 @@ module Osquery
       'wheel'
     when 'centos', 'ubuntu', 'redhat'
       'root'
+    end
+  end
+
+  def rsyslog_installed
+    inst = Mixlib::ShellOut.new('which rsyslogd')
+    inst.run_command
+    if inst.stdout.empty?
+      false
+    else
+      true
+    end
+  end
+
+  def rsyslog_legacy
+    version = Mixlib::ShellOut.new('`which rsyslogd` -v ')
+    version.run_command
+    if version.stderr.empty?
+      rsyslogd = version.stdout.split("\n")[0]
+      rsyslogd.scan(/\d.\d.\d/).first.to_f < 7.0
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,8 +39,20 @@ module Osquery
     end
   end
 
-  def rsyslog_installed
-    inst = Mixlib::ShellOut.new('which rsyslogd')
+  def osquery_latest_version
+    Chef::Version.new(node['osquery']['version'])
+  end
+
+  def osquery_current_version
+    version = Mixlib::ShellOut.new('`which osqueryi` -version')
+    version.run_command
+    return nil if version.stdout.empty?
+    osquery = version.stdout.split("\n")[0]
+    Chef::Version.new(osquery.scan(/\d.\d.\d/).first)
+  end
+
+  def app_installed(app)
+    inst = Mixlib::ShellOut.new("which #{app}")
     inst.run_command
     if inst.stdout.empty?
       false
@@ -52,10 +64,14 @@ module Osquery
   def rsyslog_legacy
     version = Mixlib::ShellOut.new('`which rsyslogd` -v ')
     version.run_command
-    if version.stderr.empty?
-      rsyslogd = version.stdout.split("\n")[0]
-      rsyslogd.scan(/\d.\d.\d/).first.to_f < 7.0
-    end
+    return nil unless version.stderr.empty?
+    rsyslogd = version.stdout.split("\n")[0]
+    rsyslogd.scan(/\d.\d.\d/).first.to_f < 7.0
+  end
+
+  def osx_upgradable
+    return true if osquery_current_version.nil?
+    osquery_current_version < osquery_latest_version
   end
 end
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -14,4 +14,14 @@ if defined?(ChefSpec)
   def delete_osquery_syslog(syslog_file)
     ChefSpec::Matchers::ResourceMatcher.new(:osquery_syslog, :delete, syslog_file)
   end
+
+  ChefSpec.define_matcher :osquery_pkg
+
+  def install_osquery_pkg(pkg_path)
+    ChefSpec::Matchers::ResourceMatcher.new(:osquery_pkg, :install, pkg_path)
+  end
+
+  def remove_osquery_pkg(pkg_path)
+    ChefSpec::Matchers::ResourceMatcher.new(:osquery_pkg, :remove, pkg_path)
+  end
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -6,4 +6,12 @@ if defined?(ChefSpec)
   def delete_osquery_config(conf)
     ChefSpec::Matchers::ResourceMatcher.new(:osquery_conf, :delete, conf)
   end
+
+  def create_osquery_syslog(syslog_file)
+    ChefSpec::Matchers::ResourceMatcher.new(:osquery_syslog, :create, syslog_file)
+  end
+
+  def delete_osquery_syslog(syslog_file)
+    ChefSpec::Matchers::ResourceMatcher.new(:osquery_syslog, :delete, syslog_file)
+  end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,15 @@ description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.1.0'
 
-%w(ubuntu centos mac_os_x).each do |os|
+%w(ubuntu centos redhat mac_os_x).each do |os|
   supports os
 end
+
+recipe 'osquery::default', 'convergence/audit requirements.'
+recipe 'osquery::centos', 'centos/redhat osquery installation.'
+recipe 'osquery::mac_os_x', 'mac os x osquery installation.'
+recipe 'osquery::ubuntu', 'ubuntu osquery installation.'
+recipe 'osquery::audit', 'chef audits for osquery installation.'
 
 chef_version '>= 12' if respond_to?(:chef_version)
 issues_url 'https://github.com/jacknagz/osquery-cookbook/issues' if respond_to?(:issues_url)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.1.0'
 
 %w(ubuntu centos mac_os_x).each do |os|
   supports os
@@ -14,6 +14,5 @@ chef_version '>= 12' if respond_to?(:chef_version)
 issues_url 'https://github.com/jacknagz/osquery-cookbook/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/jacknagz/osquery-cookbook' if respond_to?(:source_url)
 
-depends 'homebrew'
 depends 'apt'
 depends 'compat_resource'

--- a/recipes/audit.rb
+++ b/recipes/audit.rb
@@ -5,6 +5,8 @@
 # Copyright 2016, Jack Naglieri
 #
 osquery_conf = osquery_config_path
+syslog_enabled = node['osquery']['syslog']['enabled']
+syslog_file = node['osquery']['syslog']['filename']
 
 case node['platform']
 when 'mac_os_x'
@@ -55,6 +57,11 @@ when 'centos', 'ubuntu', 'redhat'
       end
       it 'should be running' do
         expect(service('osqueryd')).to be_running
+      end
+    end
+    control 'osquery rsyslog' do
+      it 'should have the config file' do
+        expect(file(syslog_file)).to exist if syslog_enabled
       end
     end
   end

--- a/recipes/audit.rb
+++ b/recipes/audit.rb
@@ -31,7 +31,10 @@ when 'mac_os_x'
     end
     control 'osquery package' do
       it 'should be installed' do
-        expect(package('osquery')).to be_installed
+        %w(osqueryi osqueryd).each do |osquery_bin|
+          expect(file("/usr/local/bin/#{osquery_bin}")).to be_file
+          expect(file("/usr/local/bin/#{osquery_bin}")).to exist
+        end
       end
       it 'should be running' do
         expect(service('com.facebook.osqueryd')).to be_running

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -24,6 +24,10 @@ rpm_package 'osquery repo' do
   action :nothing
 end
 
+osquery_syslog node['osquery']['syslog']['filename'] do
+  only_if { node['osquery']['syslog']['enabled'] }
+end
+
 package 'osquery' do
   version "#{node['osquery']['version']}-1.el#{centos_version}"
   action :install

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -6,7 +6,7 @@
 #
 
 centos_version = node['platform_version'].split('.')[0].to_i
-repo_checksum = node['osquery']['repo']["checksum#{centos_version}"]
+repo_checksum = node['osquery']['repo']["el#{centos_version}_checksum"]
 repo_url = "#{osquery_s3}/centos#{centos_version}/noarch"
 centos_repo = "osquery-s3-centos#{centos_version}-repo-1-0.0.noarch.rpm"
 file_cache = Chef::Config['file_cache_path']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@ unless supported_platforms.include?(node['platform'])
   return
 end
 
+case node['osquery']['options']['logger_plugin']
+when 'filesystem'
+  node.default['osquery']['options']['logger_path'] = '/var/log/osquery'
+end
+
 case node['platform']
 when 'redhat'
   include_recipe 'osquery::centos'

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -31,6 +31,7 @@ end
 osquery_conf osquery_config_path do
   schedule node['osquery']['schedule']
   packs node['osquery']['packs']
+  fim_paths node['osquery']['file_paths']
   notifies :restart, "service[#{domain}]"
 end
 

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -34,3 +34,8 @@ end
 service 'osqueryd' do
   action [:enable, :start]
 end
+
+osquery_syslog node['osquery']['syslog']['filename'] do
+  only_if { node['osquery']['syslog']['enabled'] }
+  notifies :restart, 'service[osqueryd]'
+end

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -27,6 +27,7 @@ end
 osquery_conf osquery_config_path do
   schedule node['osquery']['schedule']
   packs node['osquery']['packs']
+  fim_paths node['osquery']['file_paths']
   notifies :restart, 'service[osqueryd]'
 end
 

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -39,7 +39,7 @@ action :create do
     config_hash[:packs] = packs_config
   end
 
-  config_hash[:file_paths] = fim_paths unless fim_paths.empty?
+  config_hash[:file_paths] = fim_paths if node['osquery']['fim_enabled'] && !fim_paths.empty?
 
   template osquery_conf do
     source 'osquery.conf.erb'

--- a/resources/pkg.rb
+++ b/resources/pkg.rb
@@ -1,0 +1,20 @@
+property :pkg_path, kind_of: String, name_property: true
+resource_name :osquery_pkg
+
+default_action :install
+
+action :install do
+  execute 'install osquery via package' do
+    command "installer -pkg #{pkg_path} -target /"
+    user 'root'
+    action :run
+  end
+end
+
+action :remove do
+  %w(osqueryi osqueryd osqueryctl).each do |osquery_bin|
+    file osquery_bin do
+      action :delete
+    end
+  end
+end

--- a/resources/syslog.rb
+++ b/resources/syslog.rb
@@ -1,0 +1,30 @@
+property :syslog_file, kind_of: String, name_property: true
+resource_name :osquery_syslog
+
+default_action :create
+
+action :create do
+  package 'rsyslog' do
+    action :install
+    not_if { rsyslog_installed }
+  end
+
+  cookbook_file syslog_file do
+    owner 'root'
+    group 'root'
+    mode  '644'
+    source rsyslog_legacy ? 'rsyslog/osquery-legacy.conf' : 'rsyslog/osquery.conf'
+    action :create
+    notifies :restart, 'service[rsyslog]', :immediately
+  end
+
+  service 'rsyslog' do
+    action :nothing
+  end
+end
+
+action :delete do
+  cookbook_file filename do
+    action :delete
+  end
+end

--- a/resources/syslog.rb
+++ b/resources/syslog.rb
@@ -6,7 +6,7 @@ default_action :create
 action :create do
   package 'rsyslog' do
     action :install
-    not_if { rsyslog_installed }
+    not_if { app_installed('rsyslog') }
   end
 
   cookbook_file syslog_file do

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -5,14 +5,20 @@ describe 'osquery::centos' do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
       version: '7.0',
-      step_into: ['osquery_conf']
+      step_into: %w(osquery_conf osquery_syslog)
     ) do |node|
       node.set['osquery']['packs'] = %w(centos_pack)
       node.set['osquery']['version'] = '1.7.3'
+      node.set['osquery']['syslog']['enabled'] = false
     end.converge(described_recipe)
   end
 
   let(:repo) { 'osquery-s3-centos7-repo-1-0.0.noarch.rpm' }
+
+  before do
+    stub_command('which rsyslogd').and_return('/usr/sbin/rsyslogd')
+    stub_command('`which rsyslogd` -v ').and_return('rsyslogd 7.4.4 \n')
+  end
 
   it 'converges without error' do
     expect { chef_run }.not_to raise_error

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'osquery::centos' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'centos',
-                             version: '7.0',
-                             step_into: ['osquery_conf']
-                            ) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '7.0',
+      step_into: ['osquery_conf']
+    ) do |node|
       node.set['osquery']['packs'] = %w(centos_pack)
+      node.set['osquery']['version'] = '1.7.3'
     end.converge(described_recipe)
   end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,13 +3,18 @@ require 'spec_helper'
 describe 'osquery::default' do
   context 'when os_x' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.10') do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'mac_os_x',
+        version: '10.10'
+      ) do |node|
         node.set['osquery']['packs'] = %w(osx_pack)
+        node.set['osquery']['version'] = '1.7.3'
       end.converge(described_recipe)
     end
 
     before do
       stub_command('which git').and_return('/usr/bin/git')
+      stub_command('`which osqueryi` -version').and_return('osqueryi version 1.7.1')
     end
 
     it 'includes mac os x installation recipe' do
@@ -23,7 +28,10 @@ describe 'osquery::default' do
 
   context 'when ubuntu' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
         node.set['osquery']['packs'] = %w(ubuntu_pack)
       end.converge(described_recipe)
     end
@@ -39,7 +47,10 @@ describe 'osquery::default' do
 
   context 'when centos' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'centos',
+        version: '7.0'
+      ) do |node|
         node.set['osquery']['packs'] = %w(centos_pack)
       end.converge(described_recipe)
     end
@@ -55,7 +66,10 @@ describe 'osquery::default' do
 
   context 'when redhat' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0') do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'redhat',
+        version: '7.0'
+      ) do |node|
         node.set['osquery']['packs'] = %w(centos_pack)
       end.converge(described_recipe)
     end

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'osquery::mac_os_x' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'mac_os_x',
-                             version: '10.10',
-                             step_into: ['osquery_conf']
-                            ) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'mac_os_x',
+      version: '10.10',
+      step_into: ['osquery_conf']
+    ) do |node|
       node.set['osquery']['packs'] = %w(osx_pack)
+      node.set['osquery']['version'] = '1.7.3'
     end.converge(described_recipe)
   end
 

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'osquery::ubuntu' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu',
-                             version: '14.04',
-                             step_into: ['osquery_conf']
-                            ) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '14.04',
+      step_into: ['osquery_conf']
+    ) do |node|
       node.set['osquery']['packs'] = %w(ubuntu_pack)
+      node.set['osquery']['version'] = '1.7.3'
     end.converge(described_recipe)
   end
 

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -5,14 +5,21 @@ describe 'osquery::ubuntu' do
     ChefSpec::SoloRunner.new(
       platform: 'ubuntu',
       version: '14.04',
-      step_into: ['osquery_conf']
+      step_into: %w(osquery_conf osquery_syslog)
     ) do |node|
       node.set['osquery']['packs'] = %w(ubuntu_pack)
       node.set['osquery']['version'] = '1.7.3'
+      node.set['osquery']['syslog']['enabled'] = true
+      node.set['osquery']['syslog']['filename'] = '/etc/rsyslog.d/60-osquery.conf'
     end.converge(described_recipe)
   end
 
   let(:osquery_vers) { '1.7.3-1.ubuntu14' }
+
+  before do
+    stub_command('which rsyslogd').and_return('/usr/sbin/rsyslogd')
+    stub_command('`which rsyslogd` -v ').and_return('rsyslogd 7.4.4 \n')
+  end
 
   it 'converges without error' do
     expect { chef_run }.not_to raise_error
@@ -21,6 +28,13 @@ describe 'osquery::ubuntu' do
   it 'installs osquery package' do
     expect(chef_run).to install_package('osquery')
       .with(version: osquery_vers)
+  end
+
+  it 'sets up syslog configuration' do
+    expect(chef_run).to create_osquery_syslog('/etc/rsyslog.d/60-osquery.conf')
+    expect(chef_run).to install_package('rsyslog')
+    expect(chef_run.service('rsyslog')).to do_nothing
+    expect(chef_run).to create_cookbook_file('/etc/rsyslog.d/60-osquery.conf')
   end
 
   it 'creates osquery config' do


### PR DESCRIPTION
major:
* fim enable/disable: resolves #23
* adds syslog support: resolves #25 
* removes brew for `osquery_pkg` custom resource: resolves #19 

other:
* increment osquery version (to 1.7.4)
* rubocop fixes (solorunner spec spacing)
* additional `metadata` for recipes and redhat support