### PR TITLE
Schedule update, granular versions, and more

### DIFF
--- a/attributes/schedule.rb
+++ b/attributes/schedule.rb
@@ -3,10 +3,5 @@ default['osquery']['schedule'] = {
   info: {
     query: 'SELECT * FROM osquery_info;',
     interval: 86_400
-  },
-  file_events: {
-    query: 'SELECT * FROM file_events;',
-    removed: false,
-    interval: 300
   }
 }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,6 +73,31 @@ module Osquery
     return true if osquery_current_version.nil?
     osquery_current_version < osquery_latest_version
   end
+
+  def supported
+    {
+      mac_os_x: %w(10.10),
+      ubuntu: %w(12.04 14.04),
+      centos: %w(6.5 7.0),
+      redhat: %w(6.5 7.0)
+    }
+  end
+
+  def supported_platform_version
+    current_version = Chef::Version.new(node['platform_version'])
+    sp = false
+    supported[node['platform'].to_sym].each do |version|
+      required_version = Chef::Version.new(version)
+      next unless required_version.major == current_version.major
+      sp = true if required_version <= current_version
+    end
+    sp
+  end
+
+  def supported_platform
+    supported.keys.include?(node['platform'].to_sym) &&
+      supported_platform_version
+  end
 end
 
 Chef::Recipe.send(:include, Osquery)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.2'
+version '1.2.2'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,20 +5,12 @@
 # Copyright 2016, Jack Naglieri
 #
 
-supported_platforms = %w(
-  mac_os_x
-  ubuntu
-  centos
-  redhat
-)
-
-unless supported_platforms.include?(node['platform'])
-  Chef::Log.warn("** Unsupported version #{node['platform']} **")
+unless supported_platform
+  Chef::Log.warn("** Unsupported version #{node['platform']}:#{node['platform_version']} **")
   return
 end
 
-case node['osquery']['options']['logger_plugin']
-when 'filesystem'
+if node['osquery']['options']['logger_plugin'].include?('filesystem')
   node.default['osquery']['options']['logger_path'] = '/var/log/osquery'
 end
 


### PR DESCRIPTION
* schedule update: remove file events from the base schedule.  when wrapper cookbooks add a schedule, the two merge.  need to determine a better story around this workflow, but for now all schedule's will include the base `osquery_info` query.
* granular versions: restrict platforms based on version requirements hash
* adds filesystem specific plugins if filesystem exists in a list of loaded logger plugins
* tag v1.2.2