### PR TITLE
hide osquery.conf template output during chef runs

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,6 +7,6 @@ DEPENDENCIES
 GRAPH
   apt (3.0.0)
   compat_resource (12.9.1)
-  osquery (1.1.2)
+  osquery (1.2.2)
     apt (>= 0.0.0)
     compat_resource (>= 0.0.0)

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -46,6 +46,7 @@ action :create do
     mode '0440'
     owner 'root'
     group osquery_file_group
+    sensitive true
     variables(
       config: Chef::JSONCompat.to_json_pretty(config_hash)
     )


### PR DESCRIPTION
hide sensitive material in `osquery.conf` during `chef-client` runs