### PR TITLE
resource conversion, remove compat_resource dep, v1.3.0

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,7 +6,5 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  compat_resource (12.9.1)
-  osquery (1.2.2)
+  osquery (1.3.0)
     apt (>= 0.0.0)
-    compat_resource (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.2'
+version '1.3.0'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os
@@ -21,4 +21,3 @@ issues_url 'https://github.com/jacknagz/osquery-cookbook/issues' if respond_to?(
 source_url 'https://github.com/jacknagz/osquery-cookbook' if respond_to?(:source_url)
 
 depends 'apt'
-depends 'compat_resource'

--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -1,0 +1,65 @@
+use_inline_resources
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  config_hash = {
+    options: node['osquery']['options'],
+    schedule: new_resource.schedule
+  }
+
+  unless new_resource.packs.empty?
+
+    directory osquery_packs_path do
+      action :create
+      recursive true
+      mode 0644
+    end
+
+    new_resource.packs.each do |pack|
+      cookbook_file "#{osquery_packs_path}/#{pack}.conf" do
+        mode '0440'
+        source "packs/#{pack}.conf"
+        owner 'root'
+        group osquery_file_group
+        cookbook new_resource.pack_source unless new_resource.pack_source.nil?
+      end
+    end
+
+    packs_config = {}
+
+    new_resource.packs.each do |pack|
+      packs_config[pack] = "#{osquery_packs_path}/#{pack}.conf"
+    end
+
+    config_hash[:packs] = packs_config
+  end
+
+  config_hash[:file_paths] = new_resource.fim_paths if node['osquery']['fim_enabled'] && !new_resource.fim_paths.empty?
+
+  template new_resource.osquery_conf do
+    source 'osquery.conf.erb'
+    mode '0440'
+    owner 'root'
+    sensitive true
+    group osquery_file_group
+    variables(
+      config: Chef::JSONCompat.to_json_pretty(config_hash)
+    )
+  end
+  new_resource.updated_by_last_action(true)
+end
+
+action :delete do
+  file new_resource.osquery_conf do
+    action :delete
+  end
+
+  directory osquery_packs_path do
+    action :delete
+    recursive true
+  end
+  new_resource.updated_by_last_action(true)
+end

--- a/providers/pkg.rb
+++ b/providers/pkg.rb
@@ -1,0 +1,23 @@
+use_inline_resources
+
+def whyrun_supported?
+  true
+end
+
+action :install do
+  execute 'install osquery via package' do
+    command "installer -pkg #{new_resource.pkg_path} -target /"
+    user 'root'
+    action :run
+  end
+  new_resource.updated_by_last_action(true)
+end
+
+action :remove do
+  %w(osqueryi osqueryd osqueryctl).each do |osquery_bin|
+    file osquery_bin do
+      action :delete
+    end
+  end
+  new_resource.updated_by_last_action(true)
+end

--- a/providers/syslog.rb
+++ b/providers/syslog.rb
@@ -1,0 +1,33 @@
+use_inline_resources
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  package 'rsyslog' do
+    action :install
+    not_if { app_installed('rsyslog') }
+  end
+
+  cookbook_file new_resource.syslog_file do
+    owner 'root'
+    group 'root'
+    mode  '644'
+    source rsyslog_legacy ? 'rsyslog/osquery-legacy.conf' : 'rsyslog/osquery.conf'
+    action :create
+    notifies :restart, 'service[rsyslog]', :immediately
+  end
+
+  service 'rsyslog' do
+    action :nothing
+  end
+  new_resource.updated_by_last_action(true)
+end
+
+action :delete do
+  cookbook_file filename do
+    action :delete
+  end
+  new_resource.updated_by_last_action(true)
+end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -1,65 +1,8 @@
-property :osquery_conf, kind_of: String, name_property: true
-property :schedule, kind_of: Hash, default: {}, required: true
-property :packs, kind_of: Array, default: []
-property :fim_paths, kind_of: Hash, default: {}
-property :pack_source, kind_of: String
-
+actions :create, :delete
 default_action :create
 
-action :create do
-  config_hash = {
-    options: node['osquery']['options'],
-    schedule: schedule
-  }
-
-  unless packs.empty?
-
-    directory osquery_packs_path do
-      action :create
-      recursive true
-      mode 0644
-    end
-
-    packs.each do |pack|
-      cookbook_file "#{osquery_packs_path}/#{pack}.conf" do
-        mode '0440'
-        source "packs/#{pack}.conf"
-        owner 'root'
-        group osquery_file_group
-        cookbook pack_source unless pack_source.nil?
-      end
-    end
-
-    packs_config = {}
-
-    packs.each do |pack|
-      packs_config[pack] = "#{osquery_packs_path}/#{pack}.conf"
-    end
-
-    config_hash[:packs] = packs_config
-  end
-
-  config_hash[:file_paths] = fim_paths if node['osquery']['fim_enabled'] && !fim_paths.empty?
-
-  template osquery_conf do
-    source 'osquery.conf.erb'
-    mode '0440'
-    owner 'root'
-    group osquery_file_group
-    sensitive true
-    variables(
-      config: Chef::JSONCompat.to_json_pretty(config_hash)
-    )
-  end
-end
-
-action :delete do
-  file '/etc/osquery/osquery.conf' do
-    action :delete
-  end
-
-  directory osquery_packs_path do
-    action :delete
-    recursive true
-  end
-end
+attribute :osquery_conf, kind_of: String, name_attribute: true
+attribute :schedule, kind_of: Hash, default: {}, required: true
+attribute :packs, kind_of: Array, default: []
+attribute :fim_paths, kind_of: Hash, default: {}
+attribute :pack_source, kind_of: String

--- a/resources/pkg.rb
+++ b/resources/pkg.rb
@@ -1,20 +1,4 @@
-property :pkg_path, kind_of: String, name_property: true
-resource_name :osquery_pkg
-
+actions :install, :remove
 default_action :install
 
-action :install do
-  execute 'install osquery via package' do
-    command "installer -pkg #{pkg_path} -target /"
-    user 'root'
-    action :run
-  end
-end
-
-action :remove do
-  %w(osqueryi osqueryd osqueryctl).each do |osquery_bin|
-    file osquery_bin do
-      action :delete
-    end
-  end
-end
+attribute :pkg_path, kind_of: String, name_property: true

--- a/resources/syslog.rb
+++ b/resources/syslog.rb
@@ -1,30 +1,4 @@
-property :syslog_file, kind_of: String, name_property: true
-resource_name :osquery_syslog
-
+actions :create, :delete
 default_action :create
 
-action :create do
-  package 'rsyslog' do
-    action :install
-    not_if { app_installed('rsyslog') }
-  end
-
-  cookbook_file syslog_file do
-    owner 'root'
-    group 'root'
-    mode  '644'
-    source rsyslog_legacy ? 'rsyslog/osquery-legacy.conf' : 'rsyslog/osquery.conf'
-    action :create
-    notifies :restart, 'service[rsyslog]', :immediately
-  end
-
-  service 'rsyslog' do
-    action :nothing
-  end
-end
-
-action :delete do
-  cookbook_file filename do
-    action :delete
-  end
-end
+property :syslog_file, kind_of: String, name_property: true

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -37,7 +37,7 @@ describe 'osquery::centos' do
   it 'creates osquery conf via lwrp' do
     expect(chef_run)
       .to create_template('/etc/osquery/osquery.conf')
-      .with(group: 'root', user: 'root', mode: '0440')
+      .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
   end
 
   it 'install osquery repo' do


### PR DESCRIPTION
To loosen an current requirement of newer chef versions (and requiring `compat_resource`), the old style resource/provider framework is a better option.  

Additionally, added a test for the `sensitive` flag in the `osquery.conf` template.  