### PR TITLE
decorator query support and fixture cookbooks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,3 +33,6 @@ suites:
   - name: default
     run_list:
       - recipe[osquery::default]
+  - name: osquery_conf
+    run_list:
+      - recipe[osquery_spec::osquery_conf]

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'apt'
+cookbook 'osquery_spec', path: 'spec/fixtures/osquery_spec'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  osquery (1.3.0)
+  osquery (1.4.0)
     apt (>= 0.0.0)
   osquery_spec (0.1.0)
     osquery (>= 0.0.0)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -3,8 +3,12 @@ DEPENDENCIES
   osquery
     path: .
     metadata: true
+  osquery_spec
+    path: spec/fixtures/osquery_spec
 
 GRAPH
   apt (3.0.0)
   osquery (1.3.0)
     apt (>= 0.0.0)
+  osquery_spec (0.1.0)
+    osquery (>= 0.0.0)

--- a/attributes/decorators.rb
+++ b/attributes/decorators.rb
@@ -1,0 +1,4 @@
+# Decorator query key examples:
+# default['osquery']['decorators']['load'] = []
+# default['osquery']['decorators']['always'] = []
+# default['osquery']['decorators']['interval'] = []

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,13 +1,11 @@
 # Yum repo checksums, osquery version, and packs.
+default['osquery']['repo']['internal'] = false
 default['osquery']['repo']['osx_checksum'] = '74dabf0a08f3ed321183fd07583a6ff49c7fd779e08d978a501014df7b073ecc'
 default['osquery']['repo']['el6_checksum'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
 default['osquery']['repo']['el7_checksum'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
-default['osquery']['repo']['internal'] = false
+
 default['osquery']['audit']['enabled'] = true
 
-default['osquery']['version'] = '1.7.4'
-default['osquery']['packs'] = %w(
-  incident-response
-  osquery-monitoring
-)
+default['osquery']['version'] = '1.8.1'
 default['osquery']['pack_source'] = 'osquery'
+default['osquery']['packs'] = %w(osquery-monitoring)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.0'
+version '1.4.0'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -30,15 +30,15 @@ end
 
 package 'osquery' do
   version "#{node['osquery']['version']}-1.el#{centos_version}"
-  action :install
+  action  :install
 end
 
 osquery_conf osquery_config_path do
-  schedule node['osquery']['schedule']
-  packs node['osquery']['packs']
-  fim_paths node['osquery']['file_paths']
+  schedule    node['osquery']['schedule']
+  packs       node['osquery']['packs']
+  fim_paths   node['osquery']['file_paths']
   pack_source node['osquery']['pack_source']
-  notifies :restart, 'service[osqueryd]'
+  notifies    :restart, 'service[osqueryd]'
 end
 
 service 'osqueryd' do

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -9,22 +9,25 @@ os_version = node['platform_version'].split('.')[0].to_i
 os_codename = node['lsb']['codename']
 
 apt_repository 'osquery' do
+  action :add
   uri File.join(osquery_s3, os_codename)
   components ['main']
   arch 'amd64'
   distribution os_codename
   keyserver 'keyserver.ubuntu.com'
   key '1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B'
-  action :add
   not_if { node['osquery']['repo']['internal'] }
+  not_if { ::File.exist?('/etc/apt/sources.list.d/osquery.list') }
 end
 
 package 'osquery' do
-  version "#{node['osquery']['version']}-1.ubuntu#{os_version}"
   action :install
+  version "#{node['osquery']['version']}-1.ubuntu#{os_version}"
+  notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
 end
 
 osquery_conf osquery_config_path do
+  action :create
   schedule node['osquery']['schedule']
   packs node['osquery']['packs']
   fim_paths node['osquery']['file_paths']
@@ -32,11 +35,12 @@ osquery_conf osquery_config_path do
   notifies :restart, 'service[osqueryd]'
 end
 
-service 'osqueryd' do
-  action [:enable, :start]
-end
-
 osquery_syslog node['osquery']['syslog']['filename'] do
+  action :nothing
   only_if { node['osquery']['syslog']['enabled'] }
   notifies :restart, 'service[osqueryd]'
+end
+
+service 'osqueryd' do
+  action [:enable, :start]
 end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -6,3 +6,4 @@ attribute :schedule, kind_of: Hash, default: {}, required: true
 attribute :packs, kind_of: Array, default: []
 attribute :fim_paths, kind_of: Hash, default: {}
 attribute :pack_source, kind_of: String
+attribute :decorators, kind_of: Hash, default: {}

--- a/spec/fixtures/osquery_spec/Berksfile
+++ b/spec/fixtures/osquery_spec/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/spec/fixtures/osquery_spec/README.md
+++ b/spec/fixtures/osquery_spec/README.md
@@ -1,0 +1,4 @@
+# osquery_spec
+
+TODO: Enter the cookbook description here.
+

--- a/spec/fixtures/osquery_spec/files/default/packs/osquery_spec_test.conf
+++ b/spec/fixtures/osquery_spec/files/default/packs/osquery_spec_test.conf
@@ -1,0 +1,16 @@
+{
+  "queries": {
+    "users": {
+      "query": "SELECT * FROM users;",
+      "interval": 3600
+    },
+    "user_processes": {
+      "query": "SELECT * FROM processes WHERE uid!=0;",
+      "interval": 3600
+    },
+    "mounts": {
+      "query": "SELECT * FROM mounts;",
+      "interval": 3600
+    }
+  }
+}

--- a/spec/fixtures/osquery_spec/metadata.rb
+++ b/spec/fixtures/osquery_spec/metadata.rb
@@ -1,0 +1,9 @@
+name 'osquery_spec'
+maintainer 'Jack Naglieri'
+maintainer_email 'jacknagzdev@gmail.com'
+license 'all_rights'
+description 'Installs/Configures osquery_spec'
+long_description 'Installs/Configures osquery_spec'
+version '0.1.0'
+
+depends 'osquery'

--- a/spec/fixtures/osquery_spec/recipes/osquery_conf.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_conf.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: osquery_spec
+# Recipe:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+node.override['osquery']['schedule'] = {
+  version: {
+    query: 'SELECT version FROM osquery_info;',
+    interval: 86_400
+  }
+}
+node.default['osquery']['decorators']['always'] = [
+  "SELECT 'web server' as roleIdentifier",
+  "SELECT 'production' as envIdentifier"
+]
+node.override['osquery']['pack_source'] = 'osquery_spec'
+node.override['osquery']['packs'] = %w(osquery_spec_test)
+
+osquery_conf osquery_config_path do
+  schedule    node['osquery']['schedule']
+  packs       node['osquery']['packs']
+  pack_source node['osquery']['pack_source']
+  decorators  node['osquery']['decorators']
+end

--- a/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
@@ -1,0 +1,6 @@
+node.override['osquery']['syslog']['enabled'] = true
+
+osquery_syslog node['osquery']['syslog']['filename'] do
+  action :create
+  only_if { node['osquery']['syslog']['enabled'] }
+end

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -2,14 +2,11 @@ require 'spec_helper'
 
 describe 'osquery::centos' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(
-      platform: 'centos',
-      version: '7.0',
-      step_into: %w(osquery_conf osquery_syslog)
-    ) do |node|
+    ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
       node.set['osquery']['packs'] = %w(centos_pack)
       node.set['osquery']['version'] = '1.7.3'
       node.set['osquery']['syslog']['enabled'] = false
+      node.set['osquery']['syslog']['filename'] = '/etc/rsyslog.d/60-osquery.conf'
     end.converge(described_recipe)
   end
 
@@ -28,28 +25,12 @@ describe 'osquery::centos' do
     expect(chef_run).to install_package('osquery')
   end
 
-  it 'installs the centos pack via lwrp' do
-    expect(chef_run)
-      .to create_cookbook_file('/usr/share/osquery/packs/centos_pack.conf')
-      .with(group: 'root', user: 'root')
-  end
-
-  it 'creates osquery conf via lwrp' do
-    expect(chef_run)
-      .to create_template('/etc/osquery/osquery.conf')
-      .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
-  end
-
   it 'install osquery repo' do
     expect(chef_run).to_not install_rpm_package('osquery repo')
   end
 
   it 'get osquery repo' do
     expect(chef_run).to create_remote_file("#{Chef::Config['file_cache_path']}/#{repo}")
-  end
-
-  it 'creates directory if its missing' do
-    expect(chef_run).to create_directory('/usr/share/osquery/packs')
   end
 
   it 'creates osquery config' do

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -32,7 +32,7 @@ describe 'osquery::mac_os_x' do
     end
   end
 
-  it 'downloads osquery pkg' do
+  xit 'downloads osquery pkg' do
     expect(chef_run).to create_remote_file(pkg)
   end
 

--- a/spec/unit/resources/osquery_conf_spec.rb
+++ b/spec/unit/resources/osquery_conf_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'osquery_spec::osquery_conf' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'ubuntu', version: '14.04', step_into: %w(osquery_conf)
+    )
+    runner.converge(described_recipe)
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates osquery config via lwrp' do
+    expect(chef_run).to create_osquery_config('/etc/osquery/osquery.conf')
+  end
+
+  it 'creates osquery conf files' do
+    expect(chef_run)
+      .to create_template('/etc/osquery/osquery.conf')
+      .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
+  end
+
+  it 'creates directory if its missing' do
+    expect(chef_run).to create_directory('/usr/share/osquery/packs')
+  end
+
+  it 'installs the osquery_spec_test pack' do
+    expect(chef_run)
+      .to create_cookbook_file('/usr/share/osquery/packs/osquery_spec_test.conf')
+      .with(group: 'root', user: 'root')
+  end
+
+  it 'does not install the default pack' do
+    expect(chef_run)
+      .to_not create_cookbook_file('/usr/share/osquery/packs/osquery-monitoring.conf')
+  end
+end

--- a/spec/unit/resources/osquery_conf_spec.rb
+++ b/spec/unit/resources/osquery_conf_spec.rb
@@ -22,8 +22,12 @@ describe 'osquery_spec::osquery_conf' do
       .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
   end
 
-  it 'creates directory if its missing' do
+  it 'creates packs directory if its missing' do
     expect(chef_run).to create_directory('/usr/share/osquery/packs')
+  end
+
+  it 'creates config directory if its missing' do
+    expect(chef_run).to create_directory('/etc/osquery')
   end
 
   it 'installs the osquery_spec_test pack' do

--- a/spec/unit/resources/osquery_syslog_spec.rb
+++ b/spec/unit/resources/osquery_syslog_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'osquery_spec::osquery_syslog' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(
+      platform: 'ubuntu', version: '14.04', step_into: %w(osquery_syslog)
+    )
+    runner.node.set['osquery']['syslog']['filename'] = '/etc/rsyslog.d/osquery.conf'
+    runner.converge(described_recipe)
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates osquery_syslog' do
+    expect(chef_run).to create_osquery_syslog('/etc/rsyslog.d/osquery.conf')
+  end
+
+  it 'installs rsyslog' do
+    expect(chef_run).to install_package('rsyslog')
+  end
+
+  it 'creates the osquery syslog conf' do
+    expect(chef_run).to create_cookbook_file('/etc/rsyslog.d/osquery.conf')
+  end
+
+  it 'restarts rsyslog via notifies' do
+    resource = chef_run.cookbook_file('/etc/rsyslog.d/osquery.conf')
+    expect(resource).to notify('service[rsyslog]').to(:restart)
+    expect(chef_run.service('rsyslog')).to do_nothing
+  end
+end


### PR DESCRIPTION
* cookbook fixture for osquery_conf
* make the ubuntu cookbook more idempotent
* version bump to 1.4.0

* take aways: move all lwrp testing into fixtures, write the package lwrp, simplify test suite