### PR TITLE
OS X checksums and improved test suite

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,11 @@
 # Yum repo checksums, osquery version, and packs.
 default['osquery']['repo']['internal'] = false
-default['osquery']['repo']['osx_checksum'] = '74dabf0a08f3ed321183fd07583a6ff49c7fd779e08d978a501014df7b073ecc'
 default['osquery']['repo']['el6_checksum'] = '5960044255a51feda80df816fc6769c2bf4316a59fb439b50a367db52d870144'
 default['osquery']['repo']['el7_checksum'] = '86fd64c84d78072e9ad4051afd29890ff6d854984ad5b16cd84d678cd1f7ec21'
+default['osquery']['repo']['osx_checksum'] = {
+  '1.8.1' => '1a118c535d009e6837efeb17bd3f44c125d0c442e6f7f652925d864a125e9f06',
+  '1.7.4' => '74dabf0a08f3ed321183fd07583a6ff49c7fd779e08d978a501014df7b073ecc'
+}
 
 default['osquery']['audit']['enabled'] = true
 

--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -42,7 +42,7 @@ action :create do
 
   directory ::File.dirname(osquery_config_path) do
     owner 'root'
-    group 'root'
+    group osquery_file_group
     mode '0644'
   end
 

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -14,7 +14,7 @@ package_file = "#{file_cache}/#{package_name}"
 
 remote_file package_file do
   source package_url
-  checksum osx_checksum
+  checksum osx_checksum[node['osquery']['version']]
   notifies :install, "osquery_pkg[#{package_file}]", :immediately
   only_if { osx_upgradable }
   action :create

--- a/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
@@ -1,4 +1,5 @@
 node.override['osquery']['syslog']['enabled'] = true
+node.override['osquery']['syslog']['filename'] = '/etc/rsyslog.d/osquery.conf'
 
 osquery_syslog node['osquery']['syslog']['filename'] do
   action :create

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,29 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
-ChefSpec::Coverage.start!
+
+at_exit { ChefSpec::Coverage.report! }
 
 RSpec.configure do |config|
-  # Specify the path for Chef Solo file cache path (default: nil)
   config.file_cache_path = '/var/chef/cache'
-  # Specify the Chef log_level (default: :warn)
   config.log_level = :warn
+  config.color = true
+end
+
+shared_context 'converged recipe' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(node_attributes)
+    runner.converge(described_recipe)
+  end
+
+  let(:node_attributes) do
+    {}
+  end
+
+  let(:node) do
+    chef_run.node
+  end
+
+  def attribute(name)
+    node[described_cookbook][name]
+  end
 end

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -5,7 +5,7 @@ describe 'osquery::centos' do
     ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
       node.set['osquery']['packs'] = %w(centos_pack)
       node.set['osquery']['version'] = '1.7.3'
-      node.set['osquery']['syslog']['enabled'] = false
+      node.set['osquery']['syslog']['enabled'] = true
       node.set['osquery']['syslog']['filename'] = '/etc/rsyslog.d/60-osquery.conf'
     end.converge(described_recipe)
   end
@@ -19,6 +19,10 @@ describe 'osquery::centos' do
 
   it 'converges without error' do
     expect { chef_run }.not_to raise_error
+  end
+
+  it 'sets up syslog for osquery' do
+    expect(chef_run).to create_osquery_syslog('/etc/rsyslog.d/60-osquery.conf')
   end
 
   it 'installs osquery package' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,14 +2,10 @@ require 'spec_helper'
 
 describe 'osquery::default' do
   context 'when os_x' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(
-        platform: 'mac_os_x',
-        version: '10.10'
-      ) do |node|
-        node.set['osquery']['packs'] = %w(osx_pack)
-        node.set['osquery']['version'] = '1.7.3'
-      end.converge(described_recipe)
+    include_context 'converged recipe'
+
+    let(:node_attributes) do
+      { platform: 'mac_os_x', version: '10.10' }
     end
 
     before do
@@ -27,13 +23,10 @@ describe 'osquery::default' do
   end
 
   context 'when ubuntu' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(
-        platform: 'ubuntu',
-        version: '14.04'
-      ) do |node|
-        node.set['osquery']['packs'] = %w(ubuntu_pack)
-      end.converge(described_recipe)
+    include_context 'converged recipe'
+
+    let(:node_attributes) do
+      { platform: 'ubuntu', version: '14.04' }
     end
 
     it 'includes ubuntu installation recipe' do
@@ -46,13 +39,10 @@ describe 'osquery::default' do
   end
 
   context 'when centos' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(
-        platform: 'centos',
-        version: '7.0'
-      ) do |node|
-        node.set['osquery']['packs'] = %w(centos_pack)
-      end.converge(described_recipe)
+    include_context 'converged recipe'
+
+    let(:node_attributes) do
+      { platform: 'centos', version: '7.0' }
     end
 
     it 'includes centos installation recipe' do
@@ -65,13 +55,10 @@ describe 'osquery::default' do
   end
 
   context 'when redhat' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(
-        platform: 'redhat',
-        version: '7.0'
-      ) do |node|
-        node.set['osquery']['packs'] = %w(centos_pack)
-      end.converge(described_recipe)
+    include_context 'converged recipe'
+
+    let(:node_attributes) do
+      { platform: 'redhat', version: '7.0' }
     end
 
     it 'includes centos installation recipe' do

--- a/spec/unit/resources/osquery_conf_spec.rb
+++ b/spec/unit/resources/osquery_conf_spec.rb
@@ -1,43 +1,62 @@
 require 'spec_helper'
 
 describe 'osquery_spec::osquery_conf' do
-  let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-      platform: 'ubuntu', version: '14.04', step_into: %w(osquery_conf)
-    )
-    runner.converge(described_recipe)
+  context 'ubuntu' do
+    include_context 'converged recipe'
+
+    let(:node_attributes) do
+      { platform: 'ubuntu', version: '14.04', step_into: %w(osquery_conf) }
+    end
+
+    it 'converges without error' do
+      expect { chef_run }.not_to raise_error
+    end
+
+    it 'creates osquery config via lwrp' do
+      expect(chef_run).to create_osquery_config('/etc/osquery/osquery.conf')
+    end
+
+    it 'creates osquery conf files' do
+      expect(chef_run)
+        .to create_template('/etc/osquery/osquery.conf')
+        .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
+    end
+
+    it 'creates packs directory if its missing' do
+      expect(chef_run).to create_directory('/usr/share/osquery/packs')
+    end
+
+    it 'creates config directory if its missing' do
+      expect(chef_run).to create_directory('/etc/osquery')
+    end
+
+    it 'installs the osquery_spec_test pack' do
+      expect(chef_run)
+        .to create_cookbook_file('/usr/share/osquery/packs/osquery_spec_test.conf')
+        .with(group: 'root', user: 'root')
+    end
+
+    it 'does not install the default pack' do
+      expect(chef_run)
+        .to_not create_cookbook_file('/usr/share/osquery/packs/osquery-monitoring.conf')
+    end
   end
 
-  it 'converges without error' do
-    expect { chef_run }.not_to raise_error
-  end
+  context 'os x' do
+    include_context 'converged recipe'
 
-  it 'creates osquery config via lwrp' do
-    expect(chef_run).to create_osquery_config('/etc/osquery/osquery.conf')
-  end
+    let(:node_attributes) do
+      { platform: 'mac_os_x', version: '10.10', step_into: %w(osquery_conf) }
+    end
 
-  it 'creates osquery conf files' do
-    expect(chef_run)
-      .to create_template('/etc/osquery/osquery.conf')
-      .with(group: 'root', user: 'root', mode: '0440', sensitive: true)
-  end
+    it 'creates config directory if its missing' do
+      expect(chef_run).to create_directory('/var/osquery')
+    end
 
-  it 'creates packs directory if its missing' do
-    expect(chef_run).to create_directory('/usr/share/osquery/packs')
-  end
-
-  it 'creates config directory if its missing' do
-    expect(chef_run).to create_directory('/etc/osquery')
-  end
-
-  it 'installs the osquery_spec_test pack' do
-    expect(chef_run)
-      .to create_cookbook_file('/usr/share/osquery/packs/osquery_spec_test.conf')
-      .with(group: 'root', user: 'root')
-  end
-
-  it 'does not install the default pack' do
-    expect(chef_run)
-      .to_not create_cookbook_file('/usr/share/osquery/packs/osquery-monitoring.conf')
+    it 'installs the osquery_spec_test pack' do
+      expect(chef_run)
+        .to create_cookbook_file('/var/osquery/packs/osquery_spec_test.conf')
+        .with(group: 'wheel', user: 'root')
+    end
   end
 end

--- a/spec/unit/resources/osquery_syslog_spec.rb
+++ b/spec/unit/resources/osquery_syslog_spec.rb
@@ -1,12 +1,10 @@
 require 'spec_helper'
 
 describe 'osquery_spec::osquery_syslog' do
-  let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-      platform: 'ubuntu', version: '14.04', step_into: %w(osquery_syslog)
-    )
-    runner.node.set['osquery']['syslog']['filename'] = '/etc/rsyslog.d/osquery.conf'
-    runner.converge(described_recipe)
+  include_context 'converged recipe'
+
+  let(:node_attributes) do
+    { platform: 'ubuntu', version: '14.04', step_into: %w(osquery_syslog) }
   end
 
   it 'converges without error' do


### PR DESCRIPTION
* resolves #41 - adds a hash for os x packages
* use the library helper for the conf directory
* simplify test suite with shared_context