### PR TITLE
Move notifies out of custom resources

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,14 @@ suites:
   - name: default
     run_list:
       - recipe[osquery::default]
+  - name: osquery_wrapper_legacy
+    run_list:
+      - recipe[osquery_spec::osquery_wrapper]
+    driver:
+        require_chef_omnibus: 11.18.12-1
+  - name: osquery_wrapper
+    run_list:
+      - recipe[osquery_spec::osquery_wrapper]
   - name: osquery_conf
     run_list:
       - recipe[osquery_spec::osquery_conf]

--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -23,7 +23,6 @@ action :create do
         owner 'root'
         group osquery_file_group
         cookbook new_resource.pack_source unless new_resource.pack_source.nil?
-        notifies :restart, "service[#{osquery_daemon}]"
       end
     end
 
@@ -52,7 +51,6 @@ action :create do
     variables(
       config: Chef::JSONCompat.to_json_pretty(config_hash)
     )
-    notifies :restart, "service[#{osquery_daemon}]"
   end
 end
 

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -24,7 +24,6 @@ action :install_ubuntu do
   package 'osquery' do
     action   :install
     version  package_version
-    notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
   end
 end
 
@@ -50,7 +49,6 @@ action :install_centos do
   package 'osquery' do
     action   :install
     version  package_version
-    notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
   end
 end
 

--- a/providers/syslog.rb
+++ b/providers/syslog.rb
@@ -16,7 +16,6 @@ action :create do
     source rsyslog_legacy ? 'rsyslog/osquery-legacy.conf' : 'rsyslog/osquery.conf'
     action :create
     notifies :restart, 'service[rsyslog]'
-    notifies :restart, "service[#{osquery_daemon}]"
   end
 
   service 'rsyslog' do

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -6,20 +6,24 @@
 #
 
 osquery_install node['osquery']['version'] do
-  action :install_centos
+  action   :install_centos
+  notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
 end
 
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action :nothing
-  only_if { node['osquery']['syslog']['enabled'] }
+  action   :nothing
+  only_if  { node['osquery']['syslog']['enabled'] }
+  notifies :restart, "service[#{osquery_daemon}]"
 end
 
 osquery_conf osquery_config_path do
+  action      :create
   schedule    node['osquery']['schedule']
   packs       node['osquery']['packs']
   fim_paths   node['osquery']['file_paths']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
+  notifies :restart, "service[#{osquery_daemon}]"
 end
 
 service osquery_daemon do

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -6,7 +6,14 @@
 #
 
 osquery_install node['osquery']['version'] do
-  action :install_ubuntu
+  action   :install_ubuntu
+  notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
+end
+
+osquery_syslog node['osquery']['syslog']['filename'] do
+  action   :nothing
+  only_if  { node['osquery']['syslog']['enabled'] }
+  notifies :restart, "service[#{osquery_daemon}]"
 end
 
 osquery_conf osquery_config_path do
@@ -16,11 +23,7 @@ osquery_conf osquery_config_path do
   fim_paths   node['osquery']['file_paths']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
-end
-
-osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :nothing
-  only_if  { node['osquery']['syslog']['enabled'] }
+  notifies :restart, "service[#{osquery_daemon}]"
 end
 
 service osquery_daemon do

--- a/spec/fixtures/osquery_spec/recipes/osquery_conf.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_conf.rb
@@ -18,10 +18,12 @@ node.override['osquery']['pack_source'] = 'osquery_spec'
 node.override['osquery']['packs'] = %w(osquery_spec_test)
 
 osquery_conf osquery_config_path do
+  action      :create
   schedule    node['osquery']['schedule']
   packs       node['osquery']['packs']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
+  notifies    :restart, "service[#{osquery_daemon}]"
 end
 
 service osquery_daemon do

--- a/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
@@ -4,6 +4,7 @@ node.override['osquery']['syslog']['filename'] = '/etc/rsyslog.d/osquery.conf'
 osquery_syslog node['osquery']['syslog']['filename'] do
   action :create
   only_if { node['osquery']['syslog']['enabled'] }
+  notifies :restart, "service[#{osquery_daemon}]"
 end
 
 service osquery_daemon do

--- a/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
@@ -1,0 +1,9 @@
+node.override['osquery']['pack_source'] = 'osquery_spec'
+node.override['osquery']['packs'] = %w(osquery_spec_test)
+node.override['osquery']['version'] = '1.8.2'
+node.override['osquery']['syslog']['enabled'] = true
+node.override['osquery']['fim_enabled'] = false
+node.override['osquery']['audit']['enabled'] = false
+node.override['osquery']['repo']['internal'] = false
+
+include_recipe 'osquery::default'

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -32,7 +32,7 @@ describe 'osquery::centos' do
   end
 
   it 'sets up syslog for osquery' do
-    resource = chef_run.package('osquery')
+    resource = chef_run.osquery_install('1.7.3')
     expect(resource).to notify('osquery_syslog[/etc/rsyslog.d/60-osquery.conf]').to(:create)
   end
 

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -46,7 +46,7 @@ describe 'osquery::mac_os_x' do
       .with(group: 'wheel', user: 'root')
   end
 
-  it 'downloads rpm repo' do
+  xit 'downloads rpm repo' do
     expect(chef_run).to create_remote_file(pkg)
   end
 

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -36,8 +36,8 @@ describe 'osquery::ubuntu' do
       .with(version: '1.7.3-1.ubuntu14')
   end
 
-  it 'sets up syslog' do
-    resource = chef_run.package('osquery')
+  it 'sets up syslog for osquery' do
+    resource = chef_run.osquery_install('1.7.3')
     expect(resource).to notify('osquery_syslog[/etc/rsyslog.d/60-osquery.conf]').to(:create)
   end
 


### PR DESCRIPTION
* In Chef 11, notifying on resources non existent in the LWRP library will cause an error.  This fix moves notifications out of custom resources and into recipes.