### PR TITLE
remove osquery_syslog notifies and update tests

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  osquery (1.5.0)
+  osquery (1.5.2)
     apt (>= 0.0.0)
   osquery_spec (0.1.0)
     osquery (>= 0.0.0)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,6 +2,10 @@ require 'mixlib/shellout'
 
 # helper methods for common case statements
 module Osquery
+  def os_version
+    node['platform_version'].split('.')[0].to_i
+  end
+
   def osquery_daemon
     case node['platform']
     when 'mac_os_x'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.5.1'
+version '1.5.2'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -4,10 +4,10 @@ def whyrun_supported?
   true
 end
 
+# Add Apt repo and install osquery package.
 action :install_ubuntu do
-  os_version = node['platform_version'].split('.')[0].to_i
-  os_codename = node['lsb']['codename']
   package_version = "#{new_resource.version}-1.ubuntu#{os_version}"
+  os_codename = node['lsb']['codename']
 
   apt_repository 'osquery' do
     action        :add
@@ -27,16 +27,17 @@ action :install_ubuntu do
   end
 end
 
+# Setup CentOS repo and install osquery package.
 action :install_centos do
-  centos_version = node['platform_version'].split('.')[0].to_i
-  package_version = "#{new_resource.version}-1.el#{centos_version}"
-  repo_url = "#{osquery_s3}/centos#{centos_version}/noarch"
-  centos_repo = "osquery-s3-centos#{centos_version}-repo-1-0.0.noarch.rpm"
+  os_version = node['platform_version'].split('.')[0].to_i
+  package_version = "#{new_resource.version}-1.el#{os_version}"
+  repo_url = "#{osquery_s3}/centos#{os_version}/noarch"
+  centos_repo = "osquery-s3-centos#{os_version}-repo-1-0.0.noarch.rpm"
 
   remote_file "#{file_cache}/#{centos_repo}" do
     action   :create
     source   "#{repo_url}/#{centos_repo}"
-    checksum repo_hashes[:centos][centos_version]
+    checksum repo_hashes[:centos][os_version]
     notifies :install, 'rpm_package[osquery repo]', :immediately
     not_if   { node['osquery']['repo']['internal'] }
   end
@@ -52,6 +53,7 @@ action :install_centos do
   end
 end
 
+# Download os x pkg, setup directories, permissions, plist files, and install.
 action :install_os_x do
   domain = 'com.facebook.osqueryd'
   package_name = "osquery-#{new_resource.version}.pkg"
@@ -96,6 +98,7 @@ action :install_os_x do
   end
 end
 
+# remove apt repo and osquery package.
 action :remove_ubuntu do
   apt_repository 'osquery' do
     action :remove
@@ -107,9 +110,9 @@ action :remove_ubuntu do
   end
 end
 
+# remove osquery package.
 action :remove_centos do
-  centos_version = node['platform_version'].split('.')[0].to_i
-  package_version = "#{new_resource.version}-1.el#{centos_version}"
+  package_version = "#{new_resource.version}-1.el#{os_version}"
 
   package 'osquery' do
     action :remove
@@ -117,6 +120,7 @@ action :remove_centos do
   end
 end
 
+# delete osquery binary files.
 action :remove_os_x do
   %w(osqueryi osqueryd osqueryctl).each do |osquery_bin|
     file osquery_bin do

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -7,11 +7,10 @@
 
 osquery_install node['osquery']['version'] do
   action   :install_centos
-  notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
 end
 
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :nothing
+  action   :create
   only_if  { node['osquery']['syslog']['enabled'] }
   notifies :restart, "service[#{osquery_daemon}]"
 end

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -7,11 +7,10 @@
 
 osquery_install node['osquery']['version'] do
   action   :install_ubuntu
-  notifies :create, "osquery_syslog[#{node['osquery']['syslog']['filename']}]"
 end
 
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :nothing
+  action   :create
   only_if  { node['osquery']['syslog']['enabled'] }
   notifies :restart, "service[#{osquery_daemon}]"
 end

--- a/spec/fixtures/osquery_spec/files/default/packs/osquery_spec_test.conf
+++ b/spec/fixtures/osquery_spec/files/default/packs/osquery_spec_test.conf
@@ -2,15 +2,15 @@
   "queries": {
     "users": {
       "query": "SELECT * FROM users;",
-      "interval": 3600
+      "interval": 30
     },
     "user_processes": {
       "query": "SELECT * FROM processes WHERE uid!=0;",
-      "interval": 3600
+      "interval": 30
     },
     "mounts": {
       "query": "SELECT * FROM mounts;",
-      "interval": 3600
+      "interval": 30
     }
   }
 }

--- a/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
@@ -5,5 +5,8 @@ node.override['osquery']['syslog']['enabled'] = true
 node.override['osquery']['fim_enabled'] = false
 node.override['osquery']['audit']['enabled'] = false
 node.override['osquery']['repo']['internal'] = false
+node.override['osquery']['decorators']['always'] = [
+  "SELECT 'chefspec' as testIdentifier"
+]
 
 include_recipe 'osquery::default'

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -32,8 +32,7 @@ describe 'osquery::centos' do
   end
 
   it 'sets up syslog for osquery' do
-    resource = chef_run.osquery_install('1.7.3')
-    expect(resource).to notify('osquery_syslog[/etc/rsyslog.d/60-osquery.conf]').to(:create)
+    expect(chef_run).to create_osquery_syslog('/etc/rsyslog.d/60-osquery.conf')
   end
 
   it 'installs osquery package' do

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -37,8 +37,7 @@ describe 'osquery::ubuntu' do
   end
 
   it 'sets up syslog for osquery' do
-    resource = chef_run.osquery_install('1.7.3')
-    expect(resource).to notify('osquery_syslog[/etc/rsyslog.d/60-osquery.conf]').to(:create)
+    expect(chef_run).to create_osquery_syslog('/etc/rsyslog.d/60-osquery.conf')
   end
 
   it 'adds osquery apt repo' do
@@ -52,11 +51,6 @@ describe 'osquery::ubuntu' do
         packs: %w(chefspec),
         decorators: {}
       )
-  end
-
-  it 'syslog does nothing on its own' do
-    resource = chef_run.osquery_syslog('/etc/rsyslog.d/60-osquery.conf')
-    expect(resource).to do_nothing
   end
 
   it 'starts and enables osquery service' do


### PR DESCRIPTION
Before, if we updated the syslog config file post-install, nothing would happen because the osquery package was notifying the creation of the file.  This change removes that.