### PR TITLE
refactor osquery_syslog for idempotence

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,10 +40,10 @@ suites:
         syslog:
           pipe_user: 'root'
           pipe_group: 'root'
-          selector : '*.info'
+          pipe_filter : '*.info'
         options:
           verbose: true
-          syslog_pipe_path: '/var/osquery/syslog_pipe'
+          syslog_pipe_path: '/var/osquery/kitchen_pipe'
           enable_syslog: true
         schedule:
           time:

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  osquery (1.6.0)
+  osquery (1.7.0)
     apt (>= 0.0.0)
   osquery_spec (0.1.0)
     osquery (>= 0.0.0)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Config attributes add options to the osquery config `options` key.  This include
 | `['osquery']['options']['verbose']` | `Boolean` | `false` | enable verbose informational messages |
 | `['osquery']['options']['worker_threads']` | `Fixnum` | `2` | number of work dispatch threads |
 | `['osquery']['options']['enable_monitor']` | `Boolean` | `false` | enable schedule monitor |
-| `['osquery']['options']['pipe_path']` | `String` | `/var/osquery/syslog_pipe_test` | syslog pipe path |
+| `['osquery']['options']['syslog_pipe_path']` | `String` | `/var/osquery/syslog_pipe_test` | syslog pipe path |
 
 ##### attributes/schedule.rb:
 Schedule attributes control the main osquery query schedule.  You can add additional queries this way:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Config attributes add options to the osquery config `options` key.  This include
 | `['osquery']['options']['verbose']` | `Boolean` | `false` | enable verbose informational messages |
 | `['osquery']['options']['worker_threads']` | `Fixnum` | `2` | number of work dispatch threads |
 | `['osquery']['options']['enable_monitor']` | `Boolean` | `false` | enable schedule monitor |
-| `['osquery']['options']['syslog_pipe_path']` | `String` | `/var/osquery/syslog_pipe_test` | syslog pipe path |
+| `['osquery']['options']['pipe_path']` | `String` | `/var/osquery/syslog_pipe_test` | syslog pipe path |
 
 ##### attributes/schedule.rb:
 Schedule attributes control the main osquery query schedule.  You can add additional queries this way:
@@ -150,16 +150,20 @@ end
 ##### `osquery_syslog`: creates osquery syslog config file
 
 * actions: `:create` or `:delete`
-* filename: (required - name attribute) filename of the osquery syslog config
+* syslog_file: (required - name attribute) filename of the osquery syslog config
+* pipe_filter: the filter expression for routing events into the syslog pipe
+* pipe_path: the fifo pipe path
 * note: this resource installs rsyslog if not already configured
 
 `install`:
 
 ```ruby
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :create
-  only_if  { node['osquery']['syslog']['enabled'] }
-  notifies :restart, "service[#{osquery_daemon}]"
+  pipe_filter node['osquery']['syslog']['pipe_filter']
+  pipe_path   node['osquery']['options']['syslog_pipe_path']
+  action      :create
+  only_if     { node['osquery']['syslog']['enabled'] }
+  notifies    :restart, "service[#{osquery_daemon}]"
 end
 ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,9 +6,10 @@ default['osquery']['packs'] = %w(osquery-monitoring)
 # syslog options.
 default['osquery']['syslog']['enabled'] = true
 default['osquery']['syslog']['filename'] = '/etc/rsyslog.d/60-osquery.conf'
+default['osquery']['options']['syslog_pipe_path'] = '/var/osquery/syslog_pipe'
 default['osquery']['syslog']['pipe_user'] = 'root'
 default['osquery']['syslog']['pipe_group'] = 'root'
-default['osquery']['syslog']['selector'] = '*.*'
+default['osquery']['syslog']['pipe_filter'] = '*.*'
 
 # other options.
 default['osquery']['repo']['internal'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.6.1'
+version '1.7.0'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -6,13 +6,17 @@
 #
 
 osquery_install node['osquery']['version'] do
-  action   :install_centos
+  # TODO: - combine centos/ubuntu into linux and write a
+  #       generic action to determine the right platform
+  action :install_centos
 end
 
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :create
-  only_if  { node['osquery']['syslog']['enabled'] }
-  notifies :restart, "service[#{osquery_daemon}]"
+  action      :create
+  pipe_filter node['osquery']['syslog']['pipe_filter']
+  pipe_path   node['osquery']['options']['syslog_pipe_path']
+  only_if     { node['osquery']['syslog']['enabled'] }
+  notifies    :restart, "service[#{osquery_daemon}]"
 end
 
 osquery_conf osquery_config_path do

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -10,9 +10,11 @@ osquery_install node['osquery']['version'] do
 end
 
 osquery_syslog node['osquery']['syslog']['filename'] do
-  action   :create
-  only_if  { node['osquery']['syslog']['enabled'] }
-  notifies :restart, "service[#{osquery_daemon}]"
+  action      :create
+  pipe_filter node['osquery']['syslog']['pipe_filter']
+  pipe_path   node['osquery']['options']['syslog_pipe_path']
+  only_if     { node['osquery']['syslog']['enabled'] }
+  notifies    :restart, "service[#{osquery_daemon}]"
 end
 
 osquery_conf osquery_config_path do

--- a/resources/syslog.rb
+++ b/resources/syslog.rb
@@ -2,3 +2,5 @@ actions :create, :delete
 default_action :create
 
 attribute :syslog_file, kind_of: String, name_attribute: true
+attribute :pipe_filter, kind_of: String, default: '*.*'
+attribute :pipe_path, kind_of: String, default: '/var/osquery/syslog_pipe'

--- a/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_syslog.rb
@@ -2,11 +2,13 @@ node.default['osquery']['syslog']['enabled'] = true
 node.default['osquery']['syslog']['filename'] = '/etc/rsyslog.d/osquery.conf'
 node.default['osquery']['syslog']['pipe_user'] = 'root'
 node.default['osquery']['syslog']['pipe_group'] = 'root'
-node.default['osquery']['syslog']['selector'] = 'daemon,cron.*'
+node.default['osquery']['syslog']['pipe_filter'] = 'daemon,cron.*'
 node.default['osquery']['options']['syslog_pipe_path'] = '/var/osquery/syslog_pipe_test'
 
 osquery_syslog node['osquery']['syslog']['filename'] do
   action :create
+  pipe_filter node['osquery']['syslog']['pipe_filter']
+  pipe_path node['osquery']['options']['syslog_pipe_path']
   only_if { node['osquery']['syslog']['enabled'] }
   notifies :restart, "service[#{osquery_daemon}]"
 end

--- a/spec/unit/resources/osquery_syslog_spec.rb
+++ b/spec/unit/resources/osquery_syslog_spec.rb
@@ -22,7 +22,7 @@ describe 'osquery_spec::osquery_syslog' do
   it 'creates the osquery syslog conf' do
     expect(chef_run).to create_template('/etc/rsyslog.d/osquery.conf')
       .with_variables(
-        selector: 'daemon,cron.*',
+        pipe_filter: 'daemon,cron.*',
         pipe: '/var/osquery/syslog_pipe_test'
       )
   end

--- a/templates/default/rsyslog/osquery-legacy.conf.erb
+++ b/templates/default/rsyslog/osquery-legacy.conf.erb
@@ -1,2 +1,2 @@
 $template OsqueryCsvFormat, "%timestamp:::date-rfc3339,csv%,%hostname:::csv%,%syslogseverity:::csv%,%syslogfacility-text:::csv%,%syslogtag:::csv%,%msg:::csv%\n"
-<%= @selector %> |<%= @pipe %>;OsqueryCsvFormat
+<%= @pipe_filter %> |<%= @pipe %>;OsqueryCsvFormat

--- a/templates/default/rsyslog/osquery.conf.erb
+++ b/templates/default/rsyslog/osquery.conf.erb
@@ -3,4 +3,4 @@ template(
   type="string"
   string="%timestamp:::date-rfc3339,csv%,%hostname:::csv%,%syslogseverity:::csv%,%syslogfacility-text:::csv%,%syslogtag:::csv%,%msg:::csv%\n"
 )
-<%= @selector %> action(type="ompipe" Pipe="<%= @pipe %>" template="OsqueryCsvFormat")
+<%= @pipe_filter %> action(type="ompipe" Pipe="<%= @pipe %>" template="OsqueryCsvFormat")

--- a/test/integration/syslog/inspec/osquery_spec.rb
+++ b/test/integration/syslog/inspec/osquery_spec.rb
@@ -24,7 +24,7 @@ when 'debian', 'redhat'
     its('mode') { should cmp '0755' }
   end
 
-  describe file('/var/osquery/syslog_pipe') do
+  describe file('/var/osquery/kitchen_pipe') do
     it { should exist }
     it { should be_pipe }
   end


### PR DESCRIPTION
osquery_syslog changes:
* make provider idempotent - the execute ran occured on every converge
* add two new attributes - pipe_filter and pipe_path, with defaults
* update centos/ubuntu recipes with new attributes

other changes:
* rename node['osquery']['syslog']['selector'] to ['pipe_filter']
* update unit/integration tests and fixtures