### PR TITLE
Update Osquery Package Version and More

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12
 
 verifier:
   name: inspec

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  osquery (1.7.0)
+  osquery (1.7.2)
     apt (>= 0.0.0)
   osquery_spec (0.1.0)
     osquery (>= 0.0.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # osquery version and packs.
-default['osquery']['version'] = '2.3.2'
+default['osquery']['version'] = '2.4.0'
 default['osquery']['pack_source'] = 'osquery'
 default['osquery']['packs'] = %w(osquery-monitoring)
 

--- a/attributes/file_paths.rb
+++ b/attributes/file_paths.rb
@@ -1,5 +1,8 @@
-# FIM configuration.
+# FIM enable/disable.
 default['osquery']['fim_enabled'] = false
-default['osquery']['file_paths']['homes'] = ['/home/%/.ssh/%%']
-default['osquery']['file_paths']['etc'] = ['/etc/%%']
-default['osquery']['file_paths']['tmp'] = ['/tmp/%%']
+default['osquery']['file_paths'] = {}
+
+# FIM path examples.
+# default['osquery']['file_paths']['homes'] = ['/home/%/.ssh/%%']
+# default['osquery']['file_paths']['etc'] = ['/etc/%%']
+# default['osquery']['file_paths']['tmp'] = ['/tmp/%%']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -3,16 +3,7 @@ require 'mixlib/shellout'
 # helper methods for common case statements
 module Osquery
   def os_version
-    node['platform_version'].split('.')[0].to_i
-  end
-
-  def ubuntu_package_version(osquery_version)
-    case os_version
-    when '12', '14'
-      "#{osquery_version}-1.ubuntu14"
-    when '16'
-      "#{osquery_version}-1.ubuntu16"
-    end
+    node['platform_version'].to_i
   end
 
   def osquery_daemon

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jacknagzdev@gmail.com'
 license 'Apache 2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.7.1'
+version '1.7.2'
 
 %w(ubuntu centos redhat mac_os_x).each do |os|
   supports os

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -6,7 +6,7 @@ end
 
 # Add Apt repo and install osquery package.
 action :install_ubuntu do
-  package_version = ubuntu_package_version(new_resource.version)
+  package_version = "#{new_resource.version}-1.linux"
   os_codename = node['lsb']['codename']
 
   apt_repository 'osquery' do
@@ -29,7 +29,7 @@ end
 
 # Setup CentOS repo and install osquery package.
 action :install_centos do
-  package_version = "#{new_resource.version}-1.el#{os_version}"
+  package_version = "#{new_resource.version}_1.linux"
   repo_url = "#{osquery_s3}/centos#{os_version}/noarch"
   centos_repo = "osquery-s3-centos#{os_version}-repo-1-0.0.noarch.rpm"
 

--- a/providers/syslog.rb
+++ b/providers/syslog.rb
@@ -15,12 +15,12 @@ action :create do
     action :install
   end
 
-  DEFAULT_PIPE = '/var/osquery/syslog_pipe'.freeze
+  default_pipe = '/var/osquery/syslog_pipe'.freeze
   pipe_filter = new_resource.pipe_filter
   pipe_path = new_resource.pipe_path
 
   # we only need to create the pipe manually if it's not the default config
-  unless pipe_path.eql?(DEFAULT_PIPE)
+  unless pipe_path.eql?(default_pipe)
     pipe_user = node['osquery']['syslog']['pipe_user']
     pipe_group = node['osquery']['syslog']['pipe_group']
 

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -6,7 +6,7 @@ describe 'osquery::ubuntu' do
   let(:node_attributes) do
     {
       'osquery' => {
-        'version' => '1.7.3',
+        'version' => '2.3.0',
         'packs' => %w(chefspec)
       }
     }
@@ -26,7 +26,7 @@ describe 'osquery::ubuntu' do
   end
 
   it 'installs osquery' do
-    expect(chef_run).to install_osquery_ubuntu('1.7.3')
+    expect(chef_run).to install_osquery_ubuntu('2.3.0')
   end
 
   it 'installs osquery package' do

--- a/test/integration/default/inspec/osquery_spec.rb
+++ b/test/integration/default/inspec/osquery_spec.rb
@@ -26,7 +26,9 @@ when 'debian', 'redhat'
 
   describe package('osquery') do
     it { should be_installed }
+    its('version') { should eq '2.4.0-1.linux' }
   end
+
 when 'darwin'
   describe file('/var/osquery/osquery.conf') do
     it { should exist }


### PR DESCRIPTION
to @chunyong-lin 
cc @mime-frame

Per the simplification of the upstream `osquery` package creation (one package per OS vs per OS and version), this change modifies the interpolation of package versions in the `osquery_install` provider.

The snip below shows the progression in package names.
```
  Version table:
 *** 2.4.0-1.linux 0
        500 https://osquery-packages.s3.amazonaws.com/trusty/ trusty/main amd64 Packages
        100 /var/lib/dpkg/status
     2.3.4-1.u16 0
        500 https://osquery-packages.s3.amazonaws.com/trusty/ trusty/main amd64 Packages
     2.2.0-1.14 0
        500 https://osquery-packages.s3.amazonaws.com/trusty/ trusty/main amd64 Packages
     2.1.2-1.ubuntu14 0
        500 https://osquery-packages.s3.amazonaws.com/trusty/ trusty/main amd64 Packages
```

This PR also includes some minor cleanup of old code and more to support the above use case.