### PR TITLE
Xenial Support and Install instead of Upgrade

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,10 @@ platforms:
     driver:
       box: ubuntu/precise64
       box_url: https://atlas.hashicorp.com/ubuntu/boxes/precise64/versions/20160329.0.0/providers/virtualbox.box
+  - name: ubuntu/xenial64
+    driver:
+      box: ubuntu/xenial64
+      box_url: https://atlas.hashicorp.com/ubuntu/boxes/xenial64/versions/20170418.0.0/providers/virtualbox.box
 
 suites:
   - name: default

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 Metrics/LineLength:
   Max: 120
+
+Metrics/AbcSize:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This cookbook includes recipes and resources to install, configure, and start Fa
 Supported
 ------------
 #### Platforms
-  * Ubuntu: 12.04, 14.04
+  * Ubuntu: 12.04, 14.04, 16.04
   * Centos/Redhat: 6.5, 7.0
   * OS X
 

--- a/libraries/installer_helpers.rb
+++ b/libraries/installer_helpers.rb
@@ -38,7 +38,7 @@ module OsqueryInstallerHelpers
   def supported
     {
       mac_os_x: %w(10.10),
-      ubuntu: %w(12.04 14.04),
+      ubuntu: %w(12.04 14.04 16.04),
       centos: %w(6.5 7.0),
       redhat: %w(6.5 7.0)
     }
@@ -46,13 +46,11 @@ module OsqueryInstallerHelpers
 
   def supported_platform_version
     current_version = Chef::Version.new(node['platform_version'])
-    sp = false
     supported[node['platform'].to_sym].each do |version|
-      required_version = Chef::Version.new(version)
+      required_version = Chef::Version.new(version.to_f)
       next unless required_version.major == current_version.major
-      sp = true if required_version <= current_version
+      return true if required_version <= current_version
     end
-    sp
   end
 
   def supported_platform

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -1,12 +1,14 @@
 use_inline_resources
 
+PACKAGE_SUFFIX = '-1.linux'.freeze
+
 def whyrun_supported?
   true
 end
 
 # Add Apt repo and install osquery package.
 action :install_ubuntu do
-  package_version = "#{new_resource.version}-1.linux"
+  package_version = "#{new_resource.version}#{PACKAGE_SUFFIX}"
   os_codename = node['lsb']['codename']
 
   apt_repository 'osquery' do
@@ -22,14 +24,14 @@ action :install_ubuntu do
   end
 
   package 'osquery' do
-    action   :upgrade
+    action   :install
     version  package_version
   end
 end
 
 # Setup CentOS repo and install osquery package.
 action :install_centos do
-  package_version = "#{new_resource.version}_1.linux"
+  package_version = "#{new_resource.version}#{PACKAGE_SUFFIX}"
   repo_url = "#{osquery_s3}/centos#{os_version}/noarch"
   centos_repo = "osquery-s3-centos#{os_version}-repo-1-0.0.noarch.rpm"
 
@@ -47,7 +49,7 @@ action :install_centos do
   end
 
   package 'osquery' do
-    action   :upgrade
+    action   :install
     version  package_version
   end
 end

--- a/providers/syslog.rb
+++ b/providers/syslog.rb
@@ -59,7 +59,13 @@ action :create do
   end
 
   service 'rsyslog' do
-    provider Chef::Provider::Service::Upstart if node['platform'].eql?('ubuntu')
+    if node['platform'].eql?('ubuntu')
+      if os_version < 16
+        provider Chef::Provider::Service::Upstart
+      else
+        provider Chef::Provider::Service::Systemd
+      end
+    end
     supports restart: true
     action :nothing
   end

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -31,4 +31,5 @@ end
 
 service osquery_daemon do
   action [:enable, :start]
+  provider Chef::Provider::Service::Systemd if os_version.eql?(7)
 end

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -29,4 +29,5 @@ end
 
 service osquery_daemon do
   action [:enable, :start]
+  provider Chef::Provider::Service::Systemd if os_version.eql?(16)
 end

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -36,7 +36,7 @@ describe 'osquery::centos' do
   end
 
   it 'installs osquery package' do
-    expect(chef_run).to upgrade_package('osquery')
+    expect(chef_run).to install_package('osquery')
   end
 
   it 'install osquery repo' do

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -30,7 +30,7 @@ describe 'osquery::ubuntu' do
   end
 
   it 'installs osquery package' do
-    expect(chef_run).to upgrade_package('osquery')
+    expect(chef_run).to install_package('osquery')
     # .with(version: '1.7.3-1.ubuntu14')
   end
 


### PR DESCRIPTION
to: @chunyong-lin 
size: small

### Changes

* Add support for Xenial, which is mainly adding Systemd as the provider for service calls.
* Fix a bug in the install provider where it will always install the latest version.  This is unintended behavior when pinning versions.
* Add the Xenial box to the kitchen yaml.

### Testing

* Verified in Kitchen for all Linux operating systems