### PR TITLE
Add support for Oracle Enterprise Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+.DS_Store

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,14 @@ platforms:
     driver:
       box: bento/centos-7.2
       box_url: https://atlas.hashicorp.com/bento/boxes/centos-7.2/versions/2.2.5/providers/virtualbox.box
+  - name: oracle-73
+    driver:
+      box: bento/oracle-7.3
+      box_url: https://atlas.hashicorp.com/bento/boxes/oracle-7.3/versions/201708.22.0/providers/virtualbox.box
+  - name: oracle-6
+    driver:
+      box: bento/oracle-6
+      box_url: https://atlas.hashicorp.com/bento/boxes/oracle-6/versions/201708.24.0/providers/virtualbox.box
   - name: ubuntu-trusty64
     driver:
       box: ubuntu/trusty64

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  osquery (1.7.2)
+  osquery (1.8.0)
     apt (>= 0.0.0)
   osquery_spec (0.1.0)
     osquery (>= 0.0.0)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,7 +10,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       'com.facebook.osqueryd'
-    when 'centos', 'ubuntu', 'redhat'
+    when 'centos', 'ubuntu', 'redhat', 'oracle'
       'osqueryd'
     end
   end
@@ -23,7 +23,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       '/var/osquery/osquery.conf'
-    when 'centos', 'ubuntu', 'redhat'
+    when 'centos', 'ubuntu', 'redhat', 'oracle'
       '/etc/osquery/osquery.conf'
     end
   end
@@ -32,7 +32,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       '/var/osquery/packs'
-    when 'centos', 'ubuntu', 'redhat'
+    when 'centos', 'ubuntu', 'redhat', 'oracle'
       '/usr/share/osquery/packs'
     end
   end
@@ -41,7 +41,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       'wheel'
-    when 'centos', 'ubuntu', 'redhat'
+    when 'centos', 'ubuntu', 'redhat', 'oracle'
       'root'
     end
   end

--- a/libraries/installer_helpers.rb
+++ b/libraries/installer_helpers.rb
@@ -7,7 +7,7 @@ module OsqueryInstallerHelpers
   end
 
   def osquery_current_version
-    version = shell_out!('`which osqueryi` --version', :returns => [0, 127])
+    version = shell_out!('`which osqueryi` --version', returns: [0, 127])
     return nil if version.stdout.empty?
     osquery = version.stdout.split("\n")[0]
     Chef::Version.new(osquery.scan(/\d.\d.\d/).first)

--- a/libraries/installer_helpers.rb
+++ b/libraries/installer_helpers.rb
@@ -7,7 +7,7 @@ module OsqueryInstallerHelpers
   end
 
   def osquery_current_version
-    version = shell_out!('`which osqueryi` -version')
+    version = shell_out!('`which osqueryi` --version', :returns => [0, 127])
     return nil if version.stdout.empty?
     osquery = version.stdout.split("\n")[0]
     Chef::Version.new(osquery.scan(/\d.\d.\d/).first)
@@ -30,7 +30,8 @@ module OsqueryInstallerHelpers
       mac_os_x: %w(10.10),
       ubuntu: %w(12.04 14.04 16.04),
       centos: %w(6.5 7.0),
-      redhat: %w(6.5 7.0)
+      redhat: %w(6.5 7.0),
+      oracle: %w(6.5 7.0)
     }
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.8.0'
 
-%w(ubuntu centos redhat mac_os_x).each do |os|
+%w(ubuntu centos redhat oracle mac_os_x).each do |os|
   supports os
 end
 
 recipe 'osquery::default', 'convergence/audit requirements.'
-recipe 'osquery::centos', 'centos/redhat osquery installation.'
+recipe 'osquery::centos', 'centos/redhat/oracle osquery installation.'
 recipe 'osquery::mac_os_x', 'mac os x osquery installation.'
 recipe 'osquery::ubuntu', 'ubuntu osquery installation.'
 recipe 'osquery::audit', 'chef audits for osquery installation.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ if node['osquery']['options']['logger_plugin'].include?('filesystem')
 end
 
 case node['platform']
-when 'redhat'
+when 'redhat', 'oracle'
   include_recipe 'osquery::centos'
 else
   include_recipe "osquery::#{node['platform']}"

--- a/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
+++ b/spec/fixtures/osquery_spec/recipes/osquery_wrapper.rb
@@ -1,6 +1,6 @@
 node.override['osquery']['pack_source'] = 'osquery_spec'
 node.override['osquery']['packs'] = %w(osquery_spec_test)
-node.override['osquery']['version'] = '1.8.2'
+node.override['osquery']['version'] = '2.8.0'
 node.override['osquery']['syslog']['enabled'] = true
 node.override['osquery']['fim_enabled'] = false
 node.override['osquery']['audit']['enabled'] = false

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -64,4 +64,20 @@ describe 'osquery::default' do
       expect { chef_run }.not_to raise_error
     end
   end
+
+  context 'when oracle' do
+    include_context 'converged recipe'
+
+    let(:platform) do
+      { platform: 'oracle', version: '7.0' }
+    end
+
+    it 'includes centos installation recipe' do
+      expect(chef_run).to include_recipe('osquery::centos')
+    end
+
+    it 'converges without error' do
+      expect { chef_run }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
OEL can be served by the CentOS recipe in the same way Redhat can