### PR TITLE
Adding support for FIM exclude_paths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,16 @@ default['osquery']['schedule']['query_name'] = {
 | `['osquery']['schedule']` | `Hash` | osquery_info | osquery scheduled queries |
 
 ##### attributes/file_paths.rb:
-File integrity monitoring paths. 
+File integrity monitoring paths.
 
 | name   | type | default | description |
 |--------|------|---------|-------------|
 | `['osquery']['fim_enabled']` | `Boolean` | false | enable/disable file event tracking in config |
 | `['osquery']['file_paths']` | `Hash` | homes, etc, and tmp | file paths to monitor events from |
+| `['osquery']['exclude_paths']` | `Hash` | homes, etc, and tmp | file paths to ignore monitor events from (category must exist in file_paths) |
 
 ##### attributes/decorators.rb:
-Decorator query options. 
+Decorator query options.
 
 | name   | type | default | description |
 |--------|------|---------|-------------|
@@ -110,6 +111,7 @@ osquery_conf osquery_config_path do
   action      :create
   schedule    node['osquery']['schedule']
   fim_paths   node['osquery']['file_paths']
+  fim_exclude_paths   node['osquery']['exclude_paths']
   packs       node['osquery']['packs']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']

--- a/attributes/file_paths.rb
+++ b/attributes/file_paths.rb
@@ -1,8 +1,14 @@
 # FIM enable/disable.
 default['osquery']['fim_enabled'] = false
 default['osquery']['file_paths'] = {}
-
 # FIM path examples.
 # default['osquery']['file_paths']['homes'] = ['/home/%/.ssh/%%']
 # default['osquery']['file_paths']['etc'] = ['/etc/%%']
 # default['osquery']['file_paths']['tmp'] = ['/tmp/%%']
+
+default['osquery']['exclude_paths'] = {}
+# FIM path exclude examples.
+# NOTE: Category *must* already exist in file_paths to work.
+# default['osquery']['exclude_paths']['homes'] = ['/home/%/.ssh/secret.key']
+# default['osquery']['exclude_paths']['etc'] = ['/etc/nginx/%%']
+# default['osquery']['exclude_paths']['tmp'] = ['/tmp/awesomeprogram/']

--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -4,9 +4,22 @@ def whyrun_supported?
   true
 end
 
+def fim_enabled?
+  node['osquery']['fim_enabled']
+end
+
+def fim_file_paths_used?
+  fim_enabled? && !new_resource.fim_paths.empty?
+end
+
+def fim_exclude_file_paths_used?
+  fim_file_paths_used? && !new_resource.fim_exclude_paths.empty?
+end
+
 action :create do
   config_hash = { options: node['osquery']['options'], schedule: new_resource.schedule }
-  config_hash[:file_paths] = new_resource.fim_paths if node['osquery']['fim_enabled'] && !new_resource.fim_paths.empty?
+  config_hash[:file_paths] = new_resource.fim_paths if fim_file_paths_used?
+  config_hash[:exclude_paths] = new_resource.fim_exclude_paths if fim_exclude_file_paths_used?
   config_hash[:decorators] = new_resource.decorators unless new_resource.decorators.empty?
 
   unless new_resource.packs.empty?

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -25,6 +25,7 @@ osquery_conf osquery_config_path do
   schedule    node['osquery']['schedule']
   packs       node['osquery']['packs']
   fim_paths   node['osquery']['file_paths']
+  fim_exclude_paths node['osquery']['exclude_paths']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
   notifies :restart, "service[#{osquery_daemon}]"

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -4,6 +4,7 @@
 #
 # Copyright 2016, Jack Naglieri
 #
+
 domain = 'com.facebook.osqueryd'
 
 osquery_install node['osquery']['version'] do
@@ -14,6 +15,7 @@ osquery_conf osquery_config_path do
   schedule    node['osquery']['schedule']
   packs       node['osquery']['packs']
   fim_paths   node['osquery']['file_paths']
+  fim_exclude_paths node['osquery']['exclude_paths']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
   notifies    :restart, "service[#{domain}]"

--- a/recipes/ubuntu.rb
+++ b/recipes/ubuntu.rb
@@ -23,6 +23,7 @@ osquery_conf osquery_config_path do
   schedule    node['osquery']['schedule']
   packs       node['osquery']['packs']
   fim_paths   node['osquery']['file_paths']
+  fim_exclude_paths node['osquery']['exclude_paths']
   pack_source node['osquery']['pack_source']
   decorators  node['osquery']['decorators']
   notifies :restart, "service[#{osquery_daemon}]"

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -5,5 +5,6 @@ attribute :osquery_conf, kind_of: String, name_attribute: true
 attribute :schedule, kind_of: Hash, default: {}, required: true
 attribute :packs, kind_of: Array, default: []
 attribute :fim_paths, kind_of: Hash, default: {}
+attribute :fim_exclude_paths, kind_of: Hash, default: {}
 attribute :pack_source, kind_of: String
 attribute :decorators, kind_of: Hash, default: {}


### PR DESCRIPTION
Adding config file generation / option ability to use "exclude_paths" feature as defined in https://osquery.readthedocs.io/en/stable/deployment/file-integrity-monitoring/ .

Slight refactor of logic code in providers/conf.rb due to line lengths on new feature added. 