### PR TITLE
work around for using deb repo on bionic

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -12,6 +12,11 @@ action :install_ubuntu do
   package_action = new_resource.upgrade ? :upgrade : :install
   os_codename = node['lsb']['codename']
 
+  # Work around for https://github.com/facebook/osquery/issues/4338
+  if node['lsb']['codename'] == 'bionic'
+    os_codename = 'deb'
+  end
+
   apt_repository 'osquery' do
     action        :add
     uri           ::File.join(osquery_s3, os_codename)


### PR DESCRIPTION
it seems based off of https://github.com/facebook/osquery/issues/4338 the recommended approach is to use the debian package for installing osquery on ubuntu 18.  the cookbook leans on `os_codename` which won't work in the current state of things.  im not sure what the most sustainable approach is for this problem, but this simple patch works for me.

also i suppose this wouldn't be necessary since the attribute can be overridden, so it might be just a matter of documentation.