### PR TITLE
add rocky to list of rhel-based distros for configuration defaults

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -12,7 +12,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       'com.facebook.osqueryd'
-    when 'centos', 'ubuntu', 'redhat', 'amazon'
+    when 'centos', 'ubuntu', 'redhat', 'amazon', 'rocky'
       'osqueryd'
     end
   end
@@ -25,7 +25,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       '/var/osquery/osquery.conf'
-    when 'centos', 'ubuntu', 'redhat', 'amazon'
+    when 'centos', 'ubuntu', 'redhat', 'amazon', 'rocky'
       '/etc/osquery/osquery.conf'
     end
   end
@@ -34,7 +34,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       '/var/osquery/packs'
-    when 'centos', 'ubuntu', 'redhat', 'amazon'
+    when 'centos', 'ubuntu', 'redhat', 'amazon', 'rocky'
       '/usr/share/osquery/packs'
     end
   end
@@ -43,7 +43,7 @@ module Osquery
     case node['platform']
     when 'mac_os_x'
       'wheel'
-    when 'centos', 'ubuntu', 'redhat', 'amazon'
+    when 'centos', 'ubuntu', 'redhat', 'amazon', 'rocky'
       'root'
     end
   end


### PR DESCRIPTION
# Description

Found that when trying to use this cookbook while experimenting with rocky linux it fails for a null value being passed to a resource (I.e. its `name` value). This PR just fixes the case where a node's platform is `rocky`

# Context
When using the library methods for getting default values for the `osquery_daemon`, `osquery_config_path`, `osquery_packs_path` and `osquery_file_group` there is a switch statement on the nodes ohai defined `platform` value. 

And so for any platform outside of  `centos` , `ubuntu`, `redhat`, and `amazon` distributions there is no value passed to the underlying resources such as [here](https://github.com/mrichins/osquery-cookbook/blob/master/providers/conf.rb#L26)

While it is possible to override the functions to variables when using the cookbook resource directly, doing so does not appear to override the rest of the methods internally and so I've just updated the functions to provide the same response for `rocky` as it would for any of the other distributions. 

Additionally it might be nice to default to a sane value in cases where the `platform` does not match, but I am not sure what a goo value for that might be, or if it would be better to just throw a named error.
